### PR TITLE
adcs-66 - implement initial UI class

### DIFF
--- a/csdc-6/adcs-control-code/interface/inc/def_interface.hpp
+++ b/csdc-6/adcs-control-code/interface/inc/def_interface.hpp
@@ -14,6 +14,8 @@
 **/
 
 #include <stdint.h>
+#include <string>
+#include <iomanip>
 
 #pragma once
 using namespace std;
@@ -215,6 +217,20 @@ class timestamp
         friend bool operator!=(const timestamp& l, const timestamp& r)
         {
             return !(l==r);
+        }
+
+        string pretty_string()
+        {
+            uint32_t out_sec = (second + millisecond/1000);
+            uint32_t out_mil = millisecond % 1000;
+            uint32_t out_min = out_sec / 60;
+            out_sec %= 60;
+
+            stringstream formatter;
+            formatter << "[" << out_min << ":" << setw(10) << setfill('0') << out_sec << ":";
+            formatter << setw(10) << setfill('0') << out_mil << "]";
+
+            return formatter.str();
         }
 
         /*

--- a/csdc-6/adcs-simulation/cpp/inc/UI.hpp
+++ b/csdc-6/adcs-simulation/cpp/inc/UI.hpp
@@ -1,0 +1,213 @@
+/** 
+ * @file    UI.hpp
+ *
+ * @details This file describes the UI implementation. For now this is a simple command line UI
+ *          with three commands:
+ *              - "start_sim" starts a new simulation run with an initial state and desired output
+ *                 configuration files
+ *              - "restart_sim" resumes where the previous run left off but, but with a new desired
+ *                 output configuration file
+ *              - "exit" closes the terminal and ends the session
+ *
+ * @authors Aidan Sheedy
+ *
+ * Last Edited
+ * 2022-11-05
+ *
+**/
+
+#pragma once
+
+#include <String>
+#include <vector>
+#include <any>
+
+#include "Simulator.hpp"
+#include "sim_interface.hpp"
+
+using namespace std;
+
+/**
+ * @struct  text_colour
+ * 
+ * @details structure containing the ANSI escape codes for the desired text colour.
+ * 
+ * @property reset  resets the colour to the default
+ * @property red    sets the colour to red
+ * @property green  sets the colour to green
+ * @property yellow sets the colour to yellow
+**/
+static const struct
+{
+    string reset  = "\033[0m";
+    string red    = "\033[31m";
+    string green  = "\033[32m";
+    string yellow = "\033[33m";
+} text_colour;
+
+/**
+ * @class   UI
+ * 
+ * @details This class defines a basic terminal-based user interface. The functions provided allow
+ *          for future expandability to graphs, or even a more advanced GUI if desired.
+**/
+class UI
+{
+    public:
+
+        /**
+         * @name    start_ui_loop
+         * 
+         * @details Contains a basic user input that gets a user input, parses the arguments into a
+         *          vector of words, and passes the command to run_command for processing.
+        **/
+        void start_ui_loop();
+
+        /**
+         * @name    send_message
+         * 
+         * @details Function used by all internal processes and commands to send messages to the
+         *          UI. Uniformily formats the messages for consistency and clarity.
+         * 
+         * @param msg message to display to the user.
+        **/
+        void send_message(string msg);
+
+        /**
+         * @name    send_warning
+         * 
+         * @details Function used by all internal processes and commands to send warnings to the
+         *          UI. Uniformily formats the messages for consistency and clarity.
+         * 
+         * @param msg warning to display to the user.
+        **/
+        void send_warning(string msg);
+
+        /**
+         * @name    update_simulation_state
+         * 
+         * @details Function used by the simulation to udpate the user on the state of the system
+         *          at each time step. For now this just dumps the text directly to the terminal,
+         *          but it should be improved for better clarity.
+         * 
+         * @note    For now this does not allow for updating the udpate frequency, but this should
+         *          be added.
+         * 
+         * @param state state variables of the satellite, including angular position, velocity, and
+         *              acceleration.
+         * @param time  time of the update.
+        **/
+        void update_simulation_state(Satellite state, timestamp time);
+
+    private:
+        /**
+         * @typedef UI::*commandFunc
+         * 
+         * @details function pointer for internal commands. Used to map strings of commands to
+         *          their function implementation.
+        **/
+        typedef void (UI::*commandFunc)(vector<string>);
+
+        /**
+         * @name    process_input_buffer
+         * 
+         * @details splits the user input buffer into word-arguments.
+         * 
+         * @param buffer the input buffer from the user.
+         * 
+         * @returns the arguments from the buffer, split into words. Each element of the vector is
+         *          an individual argument.
+        **/
+        vector<string> process_input_buffer(string buffer);
+
+        /**
+         * @name    run_command
+         * 
+         * @details Tries to run the input command from the user. Any unknown commands will return
+         *          a warning to the user.
+         * 
+         * @param args the user input arguments
+        **/
+        void run_command(vector<string> args);
+
+        /**
+         * @name    run_simulation
+         * 
+         * @details Input command to start the simulation. Instantiates a Simulator object with the
+         *          starting and end state YAML files, and starts the simulation. Returns when the
+         *          simulation is complete.
+         * 
+         * @param args the user input arguments. Arguments are as follows:
+         *              args[0] command "start_sim"
+         *              args[1] path to the initial conditions YAML file
+         *              args[2] path to the "stop conditions" YAML file
+        **/
+        void run_simulation(vector<string> args);
+
+        /**
+         * @name    resume_simulation
+         * 
+         * @details Input command to resume the previous simulation where it left off. Takes an end
+         *          state YAML as input, and uses the previous "final state" YAML as the new
+         *          initial conditions.
+         * 
+         * @param args the user input arguments. Arguments are as follows:
+         *              args[0] command "resume_sim"
+         *              args[1] path to the "stop conditions" YAML file
+        **/
+        void resume_simulation(vector<string> args);
+
+        /**
+         * @name    quit
+         * 
+         * @details Exits the user interface, ending the session.
+         * 
+         * @param args the user input arguments. Arguments are as follows:
+         *              args[0] command "exit"
+        **/
+        void quit(vector<string> args);
+
+        /* Map linking each command to it's function implementation. Used by "run_command" */
+        const unordered_map<string, commandFunc> allowed_commands = 
+        {
+            {"start_sim",   run_simulation},
+            {"resume_sim",  resume_simulation},
+            {"exit",        quit}
+        };
+
+        /* Character used to denote user control of the terminal. */
+        const string prompt_char = ">";
+
+        /* Flag used when the terminal has been started. */
+        bool terminal_active;
+
+        /* Number of expected args for the "start_sim" command */
+        const uint8_t num_run_simulation_args = 3;
+        
+        /* Number of expected args for the "resume_sim" command */
+        const uint8_t num_resume_simulation_args = 2;
+
+        /* Number of expected args for the "exit" command */
+        const uint8_t num_exit_args = 1;
+
+        /* Path to the YAML file describing the final state of the previous simulation run. */
+        string previous_end_state_yaml;
+};
+
+/**
+ * @exception invalid_ui_args
+ * 
+ * @details exception used to indicate that a UI function has received bad arguments from the user.
+**/
+class invalid_ui_args : public exception
+{
+    public:
+        invalid_ui_args(char* msg) : message(msg) {}
+        char* what()
+        {
+            return message;
+        }
+    
+    private:
+        char* message;
+};

--- a/csdc-6/adcs-simulation/cpp/src/UI.cpp
+++ b/csdc-6/adcs-simulation/cpp/src/UI.cpp
@@ -1,0 +1,236 @@
+/** 
+ * @file    UI.cpp
+ *
+ * @details This file implements the UI class as defined in UI.hpp
+ *
+ * @authors Aidan Sheedy
+ *
+ * Last Edited
+ * 2022-11-05
+ *
+**/
+
+#pragma once
+
+#include <String>
+#include <vector>
+#include <any>
+#include <iostream>
+
+#include "UI.hpp"
+
+void UI::start_ui_loop()
+{
+    this->terminal_active = true;
+    cout << prompt_char;
+
+    /*
+     * For now terminal_active remains true. Future commands may change the flag to false to break
+     * from the loop gracefully.
+     */
+    while (terminal_active)
+    {
+        // get user input
+        string buffer;
+        getline(cin, buffer);
+
+        vector<string> args = process_input_buffer(buffer);
+        run_command(args);
+
+        cout << prompt_char;
+    }
+    return;
+}
+
+vector<string> UI::process_input_buffer(string buffer)
+{
+    stringstream   buffer_stream(buffer);
+    string         word;
+    vector<string> args;
+
+    while (buffer_stream >> word)
+    {
+        args.push_back(word);
+    }
+
+    return args;
+}
+
+void UI::run_command(vector<string> args)
+{
+    commandFunc command;
+    bool valid_function = true;
+
+    try
+    {
+        command = allowed_commands.at(args.at(0));
+    }
+    catch(const std::out_of_range& e)
+    {
+        this->send_warning("Command not found.");
+        valid_function = false;
+    }
+
+    if (valid_function)
+    {
+        try
+        {
+            (this->*command)(args);
+        }
+        catch(invalid_ui_args e)
+        {
+            this->send_warning(e.what());
+        }
+        catch(...)
+        {
+            // This block catches all exceptions, and prints the error message. The user can decide
+            // if it requires restarting the simulation, or exiting.
+            exception_ptr e = current_exception();
+            try
+            {
+                rethrow_exception(e);
+            }
+            catch(const exception& e)
+            {
+                cerr << e.what() << endl;
+            }
+        }
+    }
+
+    return;
+}
+
+void UI::run_simulation(vector<string> args)
+{
+    if (num_run_simulation_args != args.size())
+    {
+        throw invalid_ui_args("Invalid number of arguments.");
+    }
+
+    for (string arg : args)
+    {
+        if (arg.empty())
+        {
+            throw invalid_ui_args("Argument string empty!");
+        }
+    }
+
+    string initial_state_yaml   = args.at(1);
+    string exit_conditions_yaml = args.at(2);
+
+    /* 
+     * We can check for the file path existing here, but it is a race condition. The simulator
+     * should check it when it opens it and will return an exception, we can have a simple check
+     * for an "invalid file path" exception when instantiating the simulator, which is probably a
+     * better way of doing it.
+     */
+
+    // add try catch for above problem?
+    Simulator simulator(initial_state_yaml);
+
+    string final_state_yaml_path;
+   
+    /*
+     * In init, simulator should create a Control code class that has all of the sensors and 
+     * actuators. Then, this function should call simulator with a function like:
+     */
+
+    // final_state_yaml_path = simulator.begin(exit_conditions_yaml)
+
+    /*
+     * which then interprets the exit conditions (to check for), and passes them off to the
+     * controller as necessary (controller will need to know what to point at). Maybe there can be
+     * a similar function in the controller: 
+     * 
+     * controller.begin(desired_attitude)
+     * 
+     * Again when passing the exit_conditions_yaml there's a possibility that it is an invalid
+     * path. Same problem arises with it being a race condition though.
+     */
+
+    if (!final_state_yaml_path.empty())
+    {
+        /* TODO this could also check if the yaml is a valid path, but race condition again. Still,
+         * in this case it is probably worth checking because there's no point in saving it as a
+         * variable if it's invalid to start with.
+         */
+        this->previous_end_state_yaml = final_state_yaml_path;
+    }
+
+    return;
+}
+
+void UI::resume_simulation(vector<string> args)
+{
+    if (num_resume_simulation_args != args.size())
+    {
+        throw invalid_ui_args("Invalid number of arguments.");
+    }
+
+    for (string arg : args)
+    {
+        if (arg.empty())
+        {
+            throw invalid_ui_args("Argument string empty!");
+        }
+    }
+
+    /* Use previous final state yaml as new initial state */
+    vector<string> new_args = {
+        "unused",
+        this->previous_end_state_yaml,
+        args.at(1)
+    };
+    this->run_simulation(new_args);
+}
+
+void UI::quit(vector<string> args)
+{
+    if (num_exit_args != args.size())
+    {
+        throw invalid_ui_args("Invalid number of arguments.");
+    }
+    
+    send_message("exiting." + text_colour.reset);
+    exit(0);
+}
+
+void UI::send_message(string msg)
+{
+    if (msg.empty())
+    {
+        // This may need to be a different exception.
+        throw invalid_ui_args("Message to send to UI is empty.");
+    }
+
+    // This can be formatted nicely later.
+    cout << text_colour.green << msg << endl;
+    return;
+}
+
+
+void UI::send_warning(string msg)
+{
+    if (msg.empty())
+    {
+        // This may need to be a different exception.
+        throw invalid_ui_args("Warning to send to UI is empty.");
+    }
+
+    // This can be formatted nicely later.
+    cout << text_colour.yellow << "WARNING: " << msg << endl;
+    return;
+}
+
+void UI::update_simulation_state(Satellite state, timestamp time)
+{
+    // Do we need any checks on state?
+
+    // for now just text dump - next step is graphs for each.
+    cout << text_colour.reset << time.pretty_string() << "\t";
+    cout << state.theta_b.x() << ", " << state.theta_b.y() << ", " << state.theta_b.z() << ";\t";
+    cout << state.omega_b.x() << ", " << state.omega_b.y() << ", " << state.omega_b.z() << ";\t";
+    cout << state.alpha_b.x() << ", " << state.alpha_b.y() << ", " << state.alpha_b.z() << endl;
+
+    return;
+}


### PR DESCRIPTION
CHANGES
- Added a function to "timestamp" to convert to a readable string of the format: [mm:ss:ms]
- Implemented a basic terminal-style UI with three functions:
   - "start_sim" starts a new simulation run with an initial state and desired output configuration files
   - "restart_sim" resumes where the previous run left off but, but with a new desired output configuration file
   - "exit" closes the terminal and ends the session

REASON
- Need an interface for the user to interact with.

TESTING
Tested the UI with empty functions, all works as expected. Have not tried implementing with the actual simulation classes.

GITHUB LINK
https://github.com/queens-satellite-team/adcs/issues/66

Signed-off-by: Aidan Sheedy <Aidan.P.Sheedy@gmail.com>