### PR TITLE
Add pointing mode controller skeleton

### DIFF
--- a/csdc-6/adcs-control-code/inc/PointingModeController.hpp
+++ b/csdc-6/adcs-control-code/inc/PointingModeController.hpp
@@ -1,0 +1,67 @@
+/** 
+ * @file PointingModeController.hpp
+ *
+ * @details Header file for the pointing mode controller
+ *
+ * @authors Justin Paoli
+ *
+ * Last Edited
+ * 2022-11-06
+**/
+
+#pragma once
+
+#include <unordered_map>
+#include "interface.hpp"
+
+class PointingModeController {
+public:
+    /** 
+    * @class PointingModeController
+    * @param sensors [unordered_map<string, unique_ptr<Sensor>], pointers to the satellite sensors
+    * @param actuators [unordered_map<string, unique_ptr<Actuator>], pointers to the satellite actuators
+    * 
+    * @details Constructor for the pointing mode controller class. Initializes the internal references
+    * to the satellite sensors and actuators which will be used to request information from the sensors
+    * and send commands to the actuators.
+    */
+    PointingModeController(
+        unordered_map<string, unique_ptr<Sensor>> sensors, 
+        unordered_map<string, unique_ptr<Actuator>> actuators
+    );
+
+    /**
+    * @name begin
+    * @param desired_attitue [vector<float>], the desired angle to point at
+    * 
+    * @details Starts the command loop. Should call the update functions once per cycle to get
+    * updated sensor measurements and sent commands to actuators accordingly
+    */
+    void begin(vector<float> desired_attitude);
+
+private:
+    /**
+    * @property sensors [unordered_map<string, unique_ptr<Sensor>>] 
+    * 
+    * @details An unordered map containing references to the satellite sensors.
+    */
+    unordered_map<string, unique_ptr<Sensor>> sensors;
+
+    /**
+    * @property actuators [unordered_map<string, unique_ptr<Actuator>>] 
+    * 
+    * @details An unordered map containing references to the satellite actuators.
+    */
+    unordered_map<string, unique_ptr<Actuator>> actuators;
+    
+    /**
+    * @name take_updated_measurements
+    * 
+    * @details Iterates through all of the sensors, taking updated measurements from
+    * any that are ready.
+    * 
+    * TODO: should possibly not be void? Depends on if we want to store the sensor
+    * measurements as class properties or have this function return them.
+    */
+    void take_updated_measurements();
+};

--- a/csdc-6/adcs-control-code/src/PointingModeController.cpp
+++ b/csdc-6/adcs-control-code/src/PointingModeController.cpp
@@ -1,0 +1,37 @@
+/** 
+ * @file PointingModeController.cpp
+ *
+ * @details Implementation for the pointing mode controller
+ *
+ * @authors Justin Paoli
+ *
+ * Last Edited
+ * 2022-11-06
+**/
+
+#include <chrono>
+#include <thread>
+#include "PointingModeController.hpp"
+
+PointingModeController::PointingModeController(
+    unordered_map<string, unique_ptr<Sensor>> sensors, 
+    unordered_map<string, unique_ptr<Actuator>> actuators
+) {
+    this->sensors = sensors;
+    this->actuators = actuators;
+}
+
+void PointingModeController::begin(vector<float> desired_attitude) {
+    //TODO: convert to while and add exit condition
+    for (int i = 0; i < 10; i++) {
+        this->take_updated_measurements();
+        std::chrono::seconds duration(1);
+        std::this_thread::sleep_for(duration);
+    }
+}
+
+void PointingModeController::take_updated_measurements() {
+    for (const auto &s : sensors) {
+        s.second->take_measurement();
+    }
+}

--- a/csdc-6/adcs-simulation/cpp/inc/Simulator.hpp
+++ b/csdc-6/adcs-simulation/cpp/inc/Simulator.hpp
@@ -54,6 +54,13 @@ public:
     Simulator(const std::string &configFile);
 
     /**
+    * @name begin
+    * 
+    * @details Initializes the simulation by triggering the controller loop.
+    */
+    void begin();
+
+    /**
     * @name update_simulation
     * @returns [timestamp], the simulation time at the end of calculations
     *

--- a/csdc-6/adcs-simulation/cpp/src/Simulator.cpp
+++ b/csdc-6/adcs-simulation/cpp/src/Simulator.cpp
@@ -15,6 +15,7 @@
 #include "Simulator.hpp"
 #include "ConfigurationSingleton.hpp"
 #include "SensorActuatorFactory.hpp"
+#include "PointingModeController.hpp"
 
 Simulator::Simulator(const std::string &configFile) {
 
@@ -86,6 +87,11 @@ timestamp Simulator::determine_time_passed() {
     timestamp time_passed = now - this->last_called;
     this->last_called = now;
     return time_passed;
+}
+
+void Simulator::begin() {
+    PointingModeController controller(sensors, actuators);
+    controller.begin({ 0 });
 }
 
 void Simulator::simulate(timestamp t) {


### PR DESCRIPTION
Add basic pointing mode controller class. Currently doesn't do any actual controlling but serves as a way to initialize and actually run the simulation by requesting measurements once per (real-time) second, ten times.