### PR TITLE
adcs-66 - add cmake script

### DIFF
--- a/csdc-6/adcs-simulation/cpp/cmake.sh
+++ b/csdc-6/adcs-simulation/cpp/cmake.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+#### clean ####
+makefile=./Makefile
+cmake_cache=./CMakeCache.txt
+cmake_install=./cmake_install.cmake
+misc_dir=./CMakeFiles
+bin_dir=./bin
+
+if test -f $makefile; then
+    echo "removing $makefile"
+    rm $makefile
+fi
+if test -f $cmake_cache; then
+    echo "removing $cmake_cache"
+    rm $cmake_cache
+fi
+if test -f $cmake_install; then
+    echo "removing $cmake_install"
+    rm $cmake_install
+fi
+if test -d $misc_dir; then
+    echo "removing $misc_dir"
+    rm -r $misc_dir
+fi
+if test -d $bin_dir; then
+    echo "removing $bin_dir"
+    rm -r $bin_dir
+fi
+
+#### build ####
+
+if [[ "$1" != "clean" ]]
+then
+    cmake .
+fi


### PR DESCRIPTION
CHANGES
- added script to make and clean the cmake files. Options are:
  - cmake.sh       -> cleans and builds all cmake files
  - cmake.sh clean -> cleans all cmake files

REASON
- easier workflow

TESTING
- built and cleaned files succesfully

GITHUB LINK
#66 

Signed-off-by: Aidan Sheedy <Aidan.P.Sheedy@gmail.com>