### PR TITLE
Cleanup and compiler errors

### DIFF
--- a/csdc-6/adcs-control-code/inc/PointingModeController.hpp
+++ b/csdc-6/adcs-control-code/inc/PointingModeController.hpp
@@ -3,10 +3,10 @@
  *
  * @details Header file for the pointing mode controller
  *
- * @authors Justin Paoli
+ * @authors Justin Paoli, Aidan Sheedy
  *
  * Last Edited
- * 2022-11-06
+ * 2022-11-07
 **/
 
 #pragma once
@@ -24,7 +24,7 @@ public:
     * @details Constructor for the pointing mode controller class. Initializes the internal references
     * to the satellite sensors and actuators which will be used to request information from the sensors
     * and send commands to the actuators.
-    */
+   **/
     PointingModeController(
         std::unordered_map<std::string, std::shared_ptr<Sensor>> sensors,
         std::unordered_map<std::string, std::shared_ptr<Actuator>> actuators
@@ -36,7 +36,7 @@ public:
     *
     * @details Starts the command loop. Should call the update functions once per cycle to get
     * updated sensor measurements and sent commands to actuators accordingly
-    */
+   **/
     void begin(std::vector<float> desired_attitude);
 
 private:
@@ -44,14 +44,14 @@ private:
     * @property sensors [unordered_map<string, shared_ptr<Sensor>>]
     *
     * @details An unordered map containing references to the satellite sensors.
-    */
+   **/
     std::unordered_map<std::string, std::shared_ptr<Sensor>> sensors;
 
     /**
     * @property actuators [unordered_map<string, shared_ptr<Actuator>>]
     *
     * @details An unordered map containing references to the satellite actuators.
-    */
+   **/
     std::unordered_map<std::string, std::shared_ptr<Actuator>> actuators;
 
     /**
@@ -62,6 +62,6 @@ private:
     *
     * TODO: should possibly not be void? Depends on if we want to store the sensor
     * measurements as class properties or have this function return them.
-    */
+   **/
     void take_updated_measurements();
 };

--- a/csdc-6/adcs-control-code/interface/inc/def_interface.hpp
+++ b/csdc-6/adcs-control-code/interface/inc/def_interface.hpp
@@ -9,20 +9,20 @@
  * @authors Aidan Sheedy
  *
  * Last Edited
- * 2022-10-11
+ * 2022-11-07
  *
 **/
 
 #include <stdint.h>
 #include <string>
 #include <Eigen/Dense>
-// #include <iomanip>
+#include <iomanip>
 
 #pragma once
 
 /******************************************* DEFINITIONS *******************************************/
 
-/* Compiler flags */
+/* Compiler flags**/
 
 /* These flags define what version of the interface to use.
  *
@@ -30,12 +30,12 @@
  *                  control code, all other interfaces must at least follow this convention.
  * SIM_INTERFACE -  interface used by the simulation.
  * STM_INTERFACE -  interface used by the STM32 driver.
- */
+**/
 #define DEF_INTERFACE 0
 #define SIM_INTERFACE 1
 #define STM_INTERFACE 2
 
-/* Flag to indicate which interface version to use */
+/* Flag to indicate which interface version to use**/
 #define INTERFACE SIM_INTERFACE
 
 /********************************************* TYPES *********************************************/
@@ -44,37 +44,37 @@
  * @param milliseconds  number of milliseconds of the timestamp
  * @param seconds       number of seconds of the timestamp. This is rolled-over from milliseconds.
  *
- */
+**/
 class timestamp
 {
     public:
-        /*
+        /**
          * @name timestamp constructor
          *
          * @details sets initial values of millisecond and second fields.
-         */
+        **/
         timestamp(uint32_t milliseconds = 0, uint32_t seconds = 0) : millisecond(milliseconds), second(seconds) {}
 
         explicit timestamp(float real_person_time) : millisecond((float)(real_person_time - ((int)real_person_time)) * 1000.0), second(real_person_time){}; // check this conversion later its a bit hacky
-        /*
+        /**
          * @name milliseconds
          *
          * @details millisecond field accessor
          *
          * @returns millisecond field
-         */
+        **/
         uint32_t milliseconds() {return this->millisecond;}
 
-        /*
+        /**
          * @name seconds
          *
          * @details second field accessor
          *
          * @returns second field
-         */
+        **/
         uint32_t seconds() {return this->second;}
 
-        /*
+        /**
          * @name operator+ overload
          *
          * @details adds two timestamps. Overflow of milliseconds increments seconds. Overflow of
@@ -82,7 +82,7 @@ class timestamp
          *          second overflow.
          *
          * @returns result of addition.
-         */
+        **/
         timestamp operator+(const timestamp& b)
         {
             timestamp result;
@@ -111,14 +111,14 @@ class timestamp
             return result;
         }
 
-        /*
+        /**
          * @name operator- overload
          *
          * @details subtracts two timestamps. Underflow is explicitly allowed, millisecond
          *          underflow decrements the seconds field.
          *
          * @returns result of addition.
-         */
+        **/
         timestamp operator-(const timestamp& b)
         {
             timestamp result;
@@ -149,7 +149,7 @@ class timestamp
 
         explicit operator float() const { return this->millisecond / 1000.0 + (float) this->second; }
 
-        /*
+        /**
          * @name operator+ overload
          *
          * @details adds two timestamps. Overflow of milliseconds increments seconds. Overflow of
@@ -157,12 +157,21 @@ class timestamp
          *          second overflow.
          *
          * @returns result of addition.
-         */
+        **/
         timestamp operator+=(const timestamp& b)
         {
             return *this + b;
         }
 
+        /**
+         * @name operator< overload
+         *
+         * @details Compares two timestamps.
+         *
+         * @returns true if the left side is smaller than the right side. If seconds are equal, it
+         *               checks milliseconds.
+         *          false if the left side is not smaller than the right.
+        **/
         friend bool operator<(const timestamp& l, const timestamp& r)
         {
             bool ret = false;
@@ -177,21 +186,54 @@ class timestamp
             return ret;
         }
 
+        /**
+         * @name operator> overload
+         *
+         * @details compares two timestamps.
+         *
+         * @returns true if the right side is smaller than the left side. If seconds are equal, it
+         *               checks milliseconds.
+         *          false if the right side is not smaller than the left.
+        **/
         friend bool operator>(const timestamp& l, const timestamp& r)
         {
             return r < l;
         }
 
+        /**
+         * @name operator<= overload
+         *
+         * @details Compares two timestamps.
+         *
+         * @returns true if the left side is smaller or equal to the right side. 
+         *          false otherwise.
+        **/
         friend bool operator<=(const timestamp& l, const timestamp& r)
         {
             return !(l > r);
         }
 
+        /**
+         * @name operator>= overload
+         *
+         * @details Compares two timestamps.
+         *
+         * @returns true if the right side is smaller or equal to the left side. 
+         *          false otherwise.
+        **/
         friend bool operator>=(const timestamp& l, const timestamp& r)
         {
             return !(l < r);
         }
 
+        /**
+         * @name operator== overload
+         *
+         * @details Compares two timestamps.
+         *
+         * @returns true if the both sides are equal.
+         *          false otherwise.
+        **/
         friend bool operator==(const timestamp& l, const timestamp& r)
         {
             bool ret = false;
@@ -203,11 +245,27 @@ class timestamp
             return ret;
         }
 
+        /**
+         * @name operator== overload
+         *
+         * @details Compares two timestamps.
+         *
+         * @returns true if the both sides are not equal.
+         *          false otherwise.
+        **/
         friend bool operator!=(const timestamp& l, const timestamp& r)
         {
             return !(l==r);
         }
 
+        /**
+         * @name    pretty_string
+         *
+         * @details converts the timestamp to an easily readable string.
+         *
+         * @returns a string of the format:
+         *          [mm:ss:msms]
+        **/
         std::string pretty_string()
         {
             uint32_t out_sec = (second + millisecond/1000);
@@ -215,42 +273,47 @@ class timestamp
             uint32_t out_min = out_sec / 60;
             out_sec %= 60;
 
-            // stringstream formatter;
-            // formatter << "[" << out_min << ":" << setw(10) << setfill('0') << out_sec << ":";
-            // formatter << setw(10) << setfill('0') << out_mil << "]";
+            std::stringstream formatter;
+            formatter << "[" << out_min << ":" << std::setw(2) << std::setfill('0') << out_sec << ":";
+            formatter << std::setw(4) << std::setfill('0') << out_mil << "]";
 
-            return "TODO";//formatter.str();
+            return formatter.str();
         }
 
-        /*
-         * CAST FROM UINT32_T IN MS TO TIMESTAMP
-         */
-
     private:
+        /* the milliseconds of the timestamp. If overflowed, second is incremented. */
         uint32_t millisecond;
+
+        /* seconds of the timestamp. */
         uint32_t second;
 };
 
-/* Return structure from all sensors.
+/**
+ * @struct  measurement
+ * 
+ * @details Return structure from all sensors.
  *
  * @param vec           array with the values measured. Indices and frames must be maintained in
  *                      the implementation.
  * @param time_taken    time the measurement was taken.
  *
- */
+**/
 typedef struct
 {
     Eigen::Vector3f vec;
     timestamp       time_taken;
 } measurement;
 
-/* Actuator measurement structure. Used to quantify how much an actuator needs to change.
+/**
+ * @struct  actuator_state
+ * 
+ * @details Actuator measurement structure. Used to quantify how much an actuator needs to change.
  *
  * @param required_values   the desired change in values of the actuator. Indices and frames must
  *                          be maintained in the implementation.
  * @param time_requested    time the actuator change was originally requested by the control code.
  *
- */
+**/
 typedef struct {
     float       acceleration;
     float       velocity;
@@ -261,7 +324,7 @@ typedef struct {
 /******************************************* INTERFACES ******************************************/
 
 #if DEF_INTERFACE == INTERFACE
-/*
+/**
  * @class   Interface_Object
  *
  * @details This object is the highest level class in the interface. Each has a function that sends
@@ -269,22 +332,22 @@ typedef struct {
  *
  * @note    THIS IS AN ENTIRELY ABSTRACT CLASS.
  *
- */
+**/
 class ADCS_device {
     public:
-        /*
+        /**
          * @name    time_until_ready
          *
          * @details this function determines how long until the device is ready to be polled.
          *
          * @returns 0 if the device is already in a good state, otherwise the amount of time until
          *          it is ready to be polled again.
-         */
+        **/
         virtual timestamp time_until_ready();
 
 };
 
-/*
+/**
  * @class Sensor
  *
  * @details this class describes a generic sensor. It must have some way to request a measurement,
@@ -294,25 +357,25 @@ class ADCS_device {
  *
  * @note    THIS IS AN ENTIRELY ABSTRACT CLASS.
  *
- */
+**/
 class Sensor : public ADCS_device {
     public:
-        /*
+        /**
          * @name    take_measurement
          *
          * @details this function takes a measurement using the sensor.
          *
          * @returns the required measurement if succesful.
          *
-         */
+        **/
         virtual measurement take_measurement();
 
     private:
-        /* latest measurement value taken */
+        /* latest measurement value taken**/
         measurement current_value;
 };
 
-/*
+/**
  * @class Actuator
  *
  * @details this class defines a generic actuator object. It has functions to set a change in the
@@ -320,73 +383,73 @@ class Sensor : public ADCS_device {
  *
  * @implements ADCS_device
  *
- */
+**/
 class Actuator : public ADCS_device {
     public:
-        /*
+        /**
          * @name            set_output
          *
          * @param new_value the new value to set the actuators to
          *
-         */
+        **/
         virtual void set_current_accelerations(action new_value); // TODO >> this may need a return value
 
 };
 
 /******************************************** CLASSES ********************************************/
 
-/*
+/**
  * @class adcs_timer
  *
  * @details this class defines all timing interactions.
  *
- */
+**/
 class adcs_timer {
     public:
-        /*
+        /**
          * @name get_time
          *
          * @returns the current time
-         */
+        **/
         timestamp   get_time();
 
-        /*
+        /**
          * @name sleep
          *
          * @details sets the control code to sleep for a requested amount of time.
          *
          * @param time the amount of time to sleep
          *
-         */
+        **/
         void sleep(timestamp time);
 };
 
-/*
+/**
  * @class accelerometer
  *
  * @details concrete Sensor implementation for accelerometers
  *
  * @implements ADCS_device, Sensor
- */
+**/
 class accelerometer : public Sensor {};
 
-/*
+/**
  * @class gyroscope
  *
  * @details concrete Sensor implementation for gyroscopes
  *
  * @implements ADCS_device, Sensor
- */
+**/
 class gyroscope : public Sensor {};
 
-/*
+/**
  * @class Reaction_wheel
 
  *
  * @details concrete Sensor implementation for reaction wheels
  *
  * @implements ADCS_device, Actuator
- */
+**/
 class Reaction_wheel
  : public Actuator {};
 #endif

--- a/csdc-6/adcs-control-code/src/PointingModeController.cpp
+++ b/csdc-6/adcs-control-code/src/PointingModeController.cpp
@@ -22,6 +22,8 @@ PointingModeController::PointingModeController(
 }
 
 void PointingModeController::begin(std::vector<float> desired_attitude) {
+    (void) desired_attitude;    /*  Silences "unsued parameter" compiler warning. This function will be
+                                    updated later anyway so for now this is fine. */
     //TODO: convert to while and add exit condition
     for (int i = 0; i < 10; i++) {
         this->take_updated_measurements();

--- a/csdc-6/adcs-simulation/cpp/inc/CommonStructs.hpp
+++ b/csdc-6/adcs-simulation/cpp/inc/CommonStructs.hpp
@@ -3,10 +3,10 @@
  *
  * @details strongly typed sensors and actuators
  *
- * @authors Lily de Loe
+ * @authors Lily de Loe, Aidan Sheedy
  *
  * Last Edited
- * 2022-11-03
+ * 2022-11-07
  *
 **/
 #pragma once
@@ -48,6 +48,17 @@ typedef struct {
     Eigen::Matrix3f inertia_b;
 } Satellite;
 
+/**
+ * @struct  sim_reaction_wheel
+ * 
+ * @details structure defining the status of a reaction wheel in the simulator.
+ * 
+ * @param omega     the angular velocity of the reaciton wheel (body frame)
+ * @param alpha     the angular acceleration of the reaction wheel (body frame)
+ * @param inertia   the inertia matrix of the reaction wheel.
+ * @param position  the position of the satellite of the reaction wheel
+ * 
+**/
 typedef struct
 {
     Eigen::Vector3f omega;
@@ -56,22 +67,51 @@ typedef struct
     Eigen::Vector3f position;
 } sim_reaction_wheel;
 
+/**
+ * @struct  sim_accelerometer
+ * 
+ * @details structure defining the status of an accelerometer in the simulator.
+ * 
+ * @param measurement latest "measured" value of the accelerometer.
+ * @param position    the position of the satellite of the accelerometer.
+ * 
+**/
 typedef struct
 {
     Eigen::Vector3f measurement;
     Eigen::Vector3f position;
 } sim_accelerometer;
 
+/**
+ * @struct  sim_gyroscope
+ * 
+ * @details structure defining the status of an gyroscope in the simulator.
+ * 
+ * @param measurement latest "measured" value of the gyroscope.
+ * @param position    the position of the satellite of the gyroscope.
+ * 
+**/
 typedef struct
 {
     Eigen::Vector3f measurement;
     Eigen::Vector3f position;
 } sim_gyroscope;
 
+/**
+ * @struct  sim_config
+ * 
+ * @details structure defining the status of the entire satellite system in the simulation.
+ * 
+ * @param satellite         info of the overall satellite
+ * @param accelerometer     accelerometer info in the satellite system
+ * @param gyroscope         gyroscope info in the satellite system
+ * @param reaction_wheels   vector of all reaction wheels in the satellite system
+ * 
+**/
 typedef struct
 {
-    Satellite                   satellite;
-    sim_accelerometer           accelerometer;
-    sim_gyroscope               gyroscope;
+    Satellite                        satellite;
+    sim_accelerometer                accelerometer;
+    sim_gyroscope                    gyroscope;
     std::vector<sim_reaction_wheel>  reaction_wheels;
 } sim_config;

--- a/csdc-6/adcs-simulation/cpp/inc/ConfigurationSingleton.hpp
+++ b/csdc-6/adcs-simulation/cpp/inc/ConfigurationSingleton.hpp
@@ -110,24 +110,24 @@ struct ReactionWheelConfig : public ActuatorConfig {
  *
  * @details class used in configuring the satellite based on its input YAML file
  *
- */
+**/
 class Configuration {
 public:
     /**
     * @name Load
     * @param fileName [string], the input YAML file's name
     * @details loads the input YAML file
-    */
+   **/
     bool Load(const std::string &fileName);
 
     /**
     * @details copy constructor is explicitly deleted to prevent C++ from auto-generating one
-    */
+   **/
     Configuration(const Configuration &) = delete;
 
     /**
     * @details equals operator is explicitly deleted to prevent C++ from auto-generating one
-    */
+   **/
     void operator=(Configuration &) = delete;
 
     /**
@@ -135,7 +135,7 @@ public:
     * @return instance of the satellite configuration
     *
     * @details getter for an instance of the satellite's configuration
-    */
+   **/
     inline static Configuration &GetInstance() {
         static Configuration instance;
         return instance;
@@ -147,7 +147,7 @@ public:
     * @return the sensor config
     *
     * @details getter for shared pointer to the sensor config
-    */
+   **/
     inline const std::shared_ptr<SensorConfig> &GetSensorConfig(const std::string &name) {
         return sensorConfigs[name];
     };
@@ -158,7 +158,7 @@ public:
     * @return the actuator config
     *
     * @details getter for shared pointer to the actuator config
-    */
+   **/
     inline const std::shared_ptr<ActuatorConfig> &GetActuatorConfig(const std::string &name) {
         return actuatorConfigs[name];
     };
@@ -168,7 +168,7 @@ public:
     * @return the sensor configs
     *
     * @details getter for the map of sensor configs
-    */
+   **/
     inline const std::unordered_map<std::string, std::shared_ptr<SensorConfig>> &GetSensorConfigs() {
         return sensorConfigs;
     };
@@ -178,7 +178,7 @@ public:
     * @return the actuator configs
     *
     * @details getter for the map of actuator configs
-    */
+   **/
     inline const std::unordered_map<std::string, std::shared_ptr<ActuatorConfig>> &GetActuatorConfigs() {
         return actuatorConfigs;
     };
@@ -188,7 +188,7 @@ public:
     * @return the Inertia matrix for the satellite
     *
     * @details getter for shared pointer to the satellite's moment of inertia
-    */
+   **/
     inline const Eigen::Matrix3f &GetSatelliteMoment() {
         return satelliteMomentOfInertia;
     };
@@ -198,7 +198,7 @@ public:
     * @return the 3-dimensional vector representing satellite position
     *
     * @details getter for shared pointer to the satellite's position
-    */
+   **/
     inline const Eigen::Vector3f &GetSatellitePosition() {
         return satellitePosition;
     };
@@ -208,7 +208,7 @@ public:
     * @return the 3-dimensional vector representing satellite velocity
     *
     * @details getter for shared pointer to the satellite's velocity
-    */
+   **/
     inline const Eigen::Vector3f &GetSatelliteVelocity() {
         return satelliteVelocity;
     };
@@ -218,37 +218,37 @@ private:
     /**
     * @name Configuration
     * @details hidden default constructor for the satellite configuration
-    */
+   **/
     Configuration(){};
 
 private:
     /**
     * @details YAML node for the top-most heading in the YAML input file
-    */
+   **/
     YAML::Node top;
 
     /**
     * @details unordered map of sensor configs that relates strings to names
-    */
+   **/
     std::unordered_map<std::string, std::shared_ptr<SensorConfig>> sensorConfigs;
 
     /**
     * @details unordered map of actuator configs that relates strings to names
-    */
+   **/
     std::unordered_map<std::string, std::shared_ptr<ActuatorConfig>> actuatorConfigs;
 
     /**
     * @details 3-dimensional matrix storing the satellite's moment of inertia
-    */
+   **/
     Eigen::Matrix3f satelliteMomentOfInertia;
 
     /**
     * @details 3-dimensional vector storing the satellite's position
-    */
+   **/
     Eigen::Vector3f satellitePosition;
 
     /**
     * @details 3-dimensional matrix storing the satellite's velocity
-    */
+   **/
     Eigen::Vector3f satelliteVelocity;
 };

--- a/csdc-6/adcs-simulation/cpp/inc/Messenger.hpp
+++ b/csdc-6/adcs-simulation/cpp/inc/Messenger.hpp
@@ -104,12 +104,12 @@ class Messenger
 class invalid_message : public std::exception
 {
     public:
-        invalid_message(char* msg) : message(msg) {}
-        char* what()
+        invalid_message(const char* msg) : message(msg) {}
+        const char* what()
         {
             return message;
         }
 
     private:
-        char* message;
+        const char* message;
 };

--- a/csdc-6/adcs-simulation/cpp/inc/Messenger.hpp
+++ b/csdc-6/adcs-simulation/cpp/inc/Messenger.hpp
@@ -1,18 +1,13 @@
 /**
- * @file    UI.hpp
+ * @file    Messenger.hpp
  *
- * @details This file describes the UI implementation. For now this is a simple command line UI
- *          with three commands:
- *              - "start_sim" starts a new simulation run with an initial state and desired output
- *                 configuration files
- *              - "restart_sim" resumes where the previous run left off but, but with a new desired
- *                 output configuration file
- *              - "exit" closes the terminal and ends the session
+ * @details This file describes the functionality of the internal messaging from the simulation
+ *          to the user.
  *
  * @authors Aidan Sheedy
  *
  * Last Edited
- * 2022-11-05
+ * 2022-11-07
  *
 **/
 
@@ -88,18 +83,23 @@ class Messenger
         **/
         void update_simulation_state(Satellite state, timestamp time);
 
+        /**
+         * @name    prompt_char
+         *
+         * @details Function to tell the messenger to print the prompt cahracter.
+        **/
         void prompt_char();
 
     private:
-        /* Character used to denote user control of the terminal. */
+        /* Character used to denote user control of the terminal.**/
         const std::string prompt_character = ">";
 
 };
 
 /**
- * @exception invalid_ui_args
+ * @exception invalid_message
  *
- * @details exception used to indicate that a UI function has received bad arguments from the user.
+ * @details exception used to indicate that a message to the messenger is not valid.
 **/
 class invalid_message : public std::exception
 {

--- a/csdc-6/adcs-simulation/cpp/inc/SensorActuatorFactory.hpp
+++ b/csdc-6/adcs-simulation/cpp/inc/SensorActuatorFactory.hpp
@@ -1,46 +1,49 @@
 /**
- * @file Simulator.cpp
+ * @file    Simulator.cpp
  *
  * @details header file for class to create the sensor and actuator objects
  *
- * @authors Lily de Loe
+ * @authors Lily de Loe, Aidan Sheedy
  *
  * Last Edited
- * 2022-10-24
+ * 2022-11-07
  *
 **/
 
 #pragma once
 
-#include "sim_interface.hpp"
-#include "Simulator.hpp"
 #include <memory>
 
-class Simulator;
+#include "sim_interface.hpp"
+#include "Simulator.hpp"
+
+
 
 /**
  * @class SensorActuatorFactory
  *
  * @details factory class used in creating sensor and actuator objects
  *
- */
+**/
 class SensorActuatorFactory {
 public:
     /**
     * @name GetSensor
     * @param name [string], the name of the sensor
+    * @param sim pointer to the simulator that the sensors/actuators will communicate with.
     *
     * @details getter for a sensor object from singleton class instance. Returns a unique
     * pointer of the type of sensor matching the configuration
-    */
+   **/
     static std::shared_ptr<Sensor> GetSensor(const std::string &name, Simulator* sim);
 
     /**
     * @name GetActuator
     * @param name [string], the name of the actuator
+    * @param sim pointer to the simulator that the sensors/actuators will communicate with.
     *
     * @details getter for actuator object from singleton class instance. Returns a unique
     * pointer of the type of actuator matching the configuration
-    */
+   **/
     static std::shared_ptr<Actuator> GetActuator(const std::string &name, Simulator* sim);
 };

--- a/csdc-6/adcs-simulation/cpp/inc/Simulator.hpp
+++ b/csdc-6/adcs-simulation/cpp/inc/Simulator.hpp
@@ -3,10 +3,10 @@
  *
  * @details header file for class file that would configure and propagate the simulation
  *
- * @authors Lily de Loe, Justin Paoli
+ * @authors Lily de Loe, Justin Paoli, Aidan Sheedy
  *
  * Last Edited
- * 2022-11-03
+ * 2022-11-07
  *
 **/
 
@@ -24,7 +24,7 @@
  *
  * @details class for the simulator object, which is based on the YAML config file
  *
- */
+**/
 class Simulator {
 public:
     /**
@@ -34,14 +34,14 @@ public:
     * @details constructor for the simulator class. Calls the configuration
     * singleton to instantiate all of the sensors and actuators present in the
     * simulation based on the properties of the provided YAML configuration file.
-    */
+   **/
     Simulator(Messenger *messenger);
 
     /**
     * @name init
     *
     * @details Initializes the simulation with starting values.
-    */
+   **/
     void init(sim_config initial_values);
 
     /**
@@ -51,7 +51,7 @@ public:
     * @details Updates the simulation based on the amount of time the
     * control code spent running. Used when the control code requests
     * up to date values for a sensor
-    */
+   **/
     timestamp update_simulation();
 
     /**
@@ -63,89 +63,127 @@ public:
     * control code spent running plus some additional specified time.
     * Used when the control code is not ready for new sensor data and
     * intends to sleep until new data can be processed.
-    */
+   **/
     timestamp set_adcs_sleep(timestamp duration);
 
+    /**
+     * @name reaction_wheel_update_desired_state
+     * 
+     * @details udpates the simulation with the new target state of a reaction wheel.
+     * 
+     * @param wheel_position location of the reaction wheel in the satellite body.
+     * @param new_target the new target state of the reactino wheel.
+     * 
+     * @returns the time of the simulation upon return.
+     * 
+     * 
+     * @note The simulator must figure out which reaction wheel is calling the function by it's 
+     *       position - this may be changed to an ID later.
+    **/
     timestamp reaction_wheel_update_desired_state(Eigen::Vector3f wheel_position, actuator_state new_target);
 
+    /**
+     * @name reaction_wheel_get_current_state
+     * 
+     * @details request by a reaction wheel for an update on its current state.
+     * 
+     * @param position location of the reaction wheel in the satellite body.
+     * 
+     * @returns the current state of the actuator.
+     * 
+     * 
+     * @note The simulator must figure out which reaction wheel is calling the function by it's 
+     *       position - this may be changed to an ID later.
+    **/
     actuator_state reaction_wheel_get_current_state(Eigen::Vector3f position);
 
+    /**
+     * @name gyroscope_take_measurement
+     * 
+     * @details request by a gyroscope for an update on its current state.
+     * 
+     * @param measurement pointer to a measurement to fill with the current info for the sensor.
+     * 
+     * @returns the current time at the moment the measurement was taken.
+    **/
     timestamp gyroscope_take_measurement(Eigen::Vector3f *measurement);
 
+    /**
+     * @name accelerometer_take_measurement
+     * 
+     * @details request by a accelerometer for an update on its current state.
+     * 
+     * @param measurement pointer to a measurement to fill with the current info for the sensor.
+     * 
+     * @returns the current time at the moment the measurement was taken.
+    **/
     timestamp accelerometer_take_measurement(Eigen::Vector3f *measurement);
 
 private:
     /**
-    * @name simulate
-    * @param t [timestamp], the amount of time to be simulated
-    *
-    * @details Used to perform the main simulation calculations. Iterates
-    * over each timestep up until the specified timestamp t's worth
-    * of time has been simulated.
-    */
+     * @name simulate
+     * @param t [timestamp], the amount of time to be simulated
+     *
+     * @details Used to perform the main simulation calculations. Iterates
+     * over each timestep up until the specified timestamp t's worth
+     * of time has been simulated.
+    **/
     void simulate(timestamp t);
 
     /**
-    * @name timestep
-    *
-    * @details Used to perform a single timestep of simulation.
-    */
+     * @name timestep
+     *
+     * @details Used to perform a single timestep of simulation.
+    **/
     void timestep();
 
-    // /**
-    // * @name update_adcs_devices
-    // *
-    // * @details Iterates through all the known sensors and actuators and updates
-    // * their values according to the simulation to be used in the control
-    // * code.
-    // */
-    // void update_adcs_devices();
-
     /**
-    * @name determine_time_passed
-    * @returns timestamp
-    *
-    * @details Used to determine the time the control code spent running in order
-    * to account for the real-life losses due to processing speed. Does not take
-    * into account the processor the control code is running on.
-    */
+     * @name determine_time_passed
+     * @returns timestamp
+     *
+     * @details Used to determine the time the control code spent running in order
+     * to account for the real-life losses due to processing speed. Does not take
+     * into account the processor the control code is running on.
+    **/
     timestamp determine_time_passed();
 
 private:
     /**
-    * @property simulation_time [timestamp]
-    *
-    * @details The timestamp that has so far been simulated to. Initialized
-    * to 0 at the beginning of the simulation and incremented with each
-    * timestep.
-    */
+     * @property simulation_time [timestamp]
+     *
+     * @details The timestamp that has so far been simulated to. Initialized
+     * to 0 at the beginning of the simulation and incremented with each
+     * timestep.
+    **/
     timestamp simulation_time;
 
     /**
-    * @property last_called [timestamp]
-    *
-    * @details The timestamp that the simulation was last called at. Used to determine
-    * the amount of time that has passed while the control code was running.
-    */
+     * @property last_called [timestamp]
+     *
+     * @details The timestamp that the simulation was last called at. Used to determine
+     * the amount of time that has passed while the control code was running.
+    **/
     timestamp last_called;
 
     /**
-    * @property timestep_length [timestamp]
-    *
-    * @details The resolution of the simulation. Each timestep that is calcuated
-    * by the simualor will advance the simulation time by this amount.
-    */
+     * @property timestep_length [timestamp]
+     *
+     * @details The resolution of the simulation. Each timestep that is calcuated
+     * by the simualor will advance the simulation time by this amount.
+    **/
     timestamp timestep_length;
 
     /**
-    * @property satellite [Satellite]
-    *
-    * @details An instance of a satellite used to start rotational positions,
-    * velocities, and accelerations.
-    */
-    // std::shared_ptr<Satellite> satellite = std::make_shared<Satellite>();
-
+     * @property system_vals [sim_config]
+     *
+     * @details Structure containing all the current states of each aspect of the satellite system.
+    **/  
     sim_config system_vals;
 
+    /**
+     * @property messenger [Messenger*]
+     *
+     * @details pointer to a messenger object to rely messages and status updates to the user.
+    **/  
     Messenger *messenger;
 };

--- a/csdc-6/adcs-simulation/cpp/inc/UI.hpp
+++ b/csdc-6/adcs-simulation/cpp/inc/UI.hpp
@@ -12,7 +12,7 @@
  * @authors Aidan Sheedy
  *
  * Last Edited
- * 2022-11-05
+ * 2022-11-07
  *
 **/
 
@@ -85,10 +85,37 @@ class UI
         **/
         void run_simulation(std::vector<std::string> args);
 
+        /**
+         * @name create_sensor
+         *
+         * @param name [string], the name of the sensor to be created
+         * @param sim  [Simulator*], the simulator pointer to be used in the sensor constructor.
+         * @param sensors an unordered map to populate with the sensor.
+         *
+         * @details creates a sensor object and populates it in an unordered map to be used by the
+         *          control code.
+        **/
         void create_sensor(const std::string &name, Simulator *sim, std::unordered_map<std::string, std::shared_ptr<Sensor>> *sensors);
 
+        /**
+         * @name create_actuator
+         *
+         * @param name [string], the name of the actuator to be created
+         * @param sim  [Simulator*], the simulator pointer to be used in the actuator constructor.
+         * @param actuators an unordered map to populate with the actuator.
+         *
+         * @details creates an actuator object and populates it in an unordered map to be used by the
+         *          control code.
+        **/  
         void create_actuator(const std::string &name, Simulator *sim, std::unordered_map<std::string, std::shared_ptr<Actuator>> *actuators);
 
+        /**
+         * @name get_sim_config
+         * 
+         * @param config configuration singleton used to get the simulation initial parameters.
+         * 
+         * @returns the initial configuration fo the satellite 
+        **/
         sim_config get_sim_config(Configuration &config);
 
         /**
@@ -122,24 +149,25 @@ class UI
         **/
         using commandFunc = std::function<void(std::vector<std::string>)>;
 
+        /* Messenger object used to send information to the user. */
         Messenger messenger;
 
-        /* Map linking each command to it's function implementation. Used by "run_command" */
+        /* Map linking each command to it's function implementation. Used by "run_command"**/
         std::unordered_map<std::string, commandFunc> allowed_commands;
 
-        /* Flag used when the terminal has been started. */
+        /* Flag used when the terminal has been started.**/
         bool terminal_active;
 
-        /* Number of expected args for the "start_sim" command */
+        /* Number of expected args for the "start_sim" command**/
         const uint8_t num_run_simulation_args = 3;
 
-        /* Number of expected args for the "resume_sim" command */
+        /* Number of expected args for the "resume_sim" command**/
         const uint8_t num_resume_simulation_args = 2;
 
-        /* Number of expected args for the "exit" command */
+        /* Number of expected args for the "exit" command**/
         const uint8_t num_exit_args = 1;
 
-        /* Path to the YAML file describing the final state of the previous simulation run. */
+        /* Path to the YAML file describing the final state of the previous simulation run.**/
         std::string previous_end_state_yaml;
 };
 

--- a/csdc-6/adcs-simulation/cpp/inc/UI.hpp
+++ b/csdc-6/adcs-simulation/cpp/inc/UI.hpp
@@ -179,12 +179,12 @@ class UI
 class invalid_ui_args : public std::exception
 {
     public:
-        invalid_ui_args(char* msg) : message(msg) {}
-        char* what()
+        invalid_ui_args(const char* msg) : message(msg) {}
+        const char* what()
         {
             return message;
         }
 
     private:
-        char* message;
+        const char* message;
 };

--- a/csdc-6/adcs-simulation/cpp/interface/inc/sim_interface.hpp
+++ b/csdc-6/adcs-simulation/cpp/interface/inc/sim_interface.hpp
@@ -1,4 +1,4 @@
-/** @file sim_interface.hpp
+/** @file   sim_interface.hpp
  *
  * @details This file defines the interface between the control code and the simulation. It expands
  *          interface.hpp by adding simulation specific functions as required to the interface.
@@ -6,7 +6,7 @@
  * @authors Aidan Sheedy
  *
  * Last Edited
- * 2022-10-11
+ * 2022-11-07
  *
 **/
 #include <vector>
@@ -19,96 +19,115 @@
 
 #if SIM_INTERFACE == INTERFACE
 
-/*
+/**
  * @class   Interface_Object
  *
  * @details This object is the highest level class in the interface, and describes any physical
  *          in the ADCS. Primary devices are Actuators and Sensors, and they all have some polling
  *          rate that is implemented in this class.
  *
- */
+**/
 class ADCS_device {
     public:
-        /*
+        /**
          * @name ADCS_device constructor
          *
-         * @details constructor for ADCS_device. Only check is to see if the sim is void.
-         */
+         * @details constructor for ADCS_device.
+         * 
+         * @param polling_time the minimum amount of time between polling events for the device
+         * @param sim          simulator object used to update and get updates about the device
+        **/
         ADCS_device(timestamp polling_time, Simulator* sim);
 
+        /**
+         * @name ADCS_device destructor
+         *
+         * @details virtual as this class is a base class with virtual functions.
+        **/
         virtual ~ADCS_device(){}
 
-        /*
+        /**
          * @name    time_until_ready
          *
          * @details this function determines how long until the device is ready to be polled.
          *
          * @returns 0 if the device is already in a good state, otherwise the amount of time until
          *          it is ready to be polled again.
-         */
+        **/
         virtual timestamp time_until_ready();
 
     private:
         // TODO: This may need an accessor - for now not implementing.
-        /* Minimum amount of time that must pass between each time the device is polled. */
+        /* Minimum amount of time that must pass between each time the device is polled.**/
         timestamp min_polling_increment;
 
-        /* Last time the device was polled. */
+        /* Last time the device was polled.**/
         timestamp last_polled;
 
     protected:
-        /*
+        /**
          * @name    update_poll_time
          *
          * @details this function updates the last time the last time the device was polled.
          *
          * @param   new_time the latest poll time of the device.
-         */
+        **/
         void update_poll_time(timestamp new_time);
 
-        /*
+        /**
          * @name sim
          *
          * @details Pointer to the simulation object that instantiated the ADCS_device. Used to
          *          tell the simulation to advance. This essentially "passes control" back to the
          *          simulation.
-         */
+        **/
         Simulator* sim;
 
 };
 
-/*
+/**
  * @class Sensor
  *
  * @details this class describes a generic sensor. It must have some way to request a measurement,
  *          and a way to ensure the sensor is ready for a new measurement.
  *
  * @implements ADCS_device
- */
+**/
 class Sensor : public ADCS_device {
     public:
-        /*
+        /**
          * @name Sensor constructor
          *
          * @details constructor for Sensor. Only check is to see if the sim is void. Passes
          *          polling_time and sim to parent class, and populates all other parameters if
          *          they are valid.
-         */
+         * 
+         * @param polling_time  polling time of the sensor
+         * @param sim           simulator object used to update and get updates about the device
+         * @param positions     positions of all sensor locations on the satellite
+         * @param num_sensors   number of sensor locations on the satellite
+         * @param num_axes      number of axes each sensor location measures
+        **/
         Sensor(timestamp polling_time, Simulator* sim, std::vector<Eigen::Vector3f> positions, uint32_t num_sensors, uint32_t num_axes);
 
+        /**
+         * @name Sensor destructor
+         *
+         * @details virtual as this class is a base class with virtual functions.
+        **/
         virtual ~Sensor(){}
 
-        /*
+        /**
          * @name    take_measurement
          *
          * @details this function takes a measurement using the sensor. The simulation is also told
          *          to update.
          *
          * @returns the required measurement if succesful.
-         */
-        virtual measurement take_measurement(){} // MAY NEED TO REMOVE THIS OR CHANGE IT
+        **/
+        virtual measurement take_measurement(){} // MAY need to create a default implementation
 
-        /*
+        /**
          * @name    set_current_vals
          *
          * @details this function sets the new raw sensor values from the simulation and calculates
@@ -119,72 +138,79 @@ class Sensor : public ADCS_device {
          * @param   physical_vals   vector of physical measuremnts for each sensor. The vector size
          *                          is the number of sensors, and the matrix size is the number of
          *                          axis for each measurement.
-         */
+         * @param   time            the time the measurement was taken.
+        **/
         virtual void set_current_vals(std::vector<Eigen::VectorXf> physical_vals, timestamp time);
 
-        /*
+        /**
          * @name    get_positions
          *
          * @details positions vector accessor.
          *
          * @returns positions of each physical sensor.
-         */
+        **/
         std::vector<Eigen::Vector3f> get_positions();
 
     protected:
-        /* Latest measurement value taken */
+        /* Latest measurement value taken**/
         measurement current_vector_value;
 
     private:
         /* Number of physical sensors in the sensor unit*/
         uint32_t num_sensors;
 
-        /* Number of axes per physical sensor */
+        /* Number of axes per physical sensor**/
         uint32_t num_axes;
 
-        /* Positions of each satellite within the satellite body. Dimensions are num_sensors x 3 */
+        /* Positions of each satellite within the satellite body. Dimensions are num_sensors x 3**/
         std::vector<Eigen::Vector3f> positions;
 };
 
-/*
+/**
  * @class Actuator
  *
  * @details this class defines a generic actuator object. It has functions to set a change in the
  *          actuator values, and to check when the actuator can be updated again.
  *
  * @implements ADCS_device
- */
+**/
 class Actuator : public ADCS_device
 {
     public:
-        /*
+        /**
          * @name Actuator constructor
          *
          * @details constructor for actuators. Initial values for current and target states are 0.
-         */
+        **/
         Actuator(timestamp polling_time, Simulator* sim, Eigen::Vector3f position, actuator_state max_vals, actuator_state min_vals);
+
+        /**
+         * @name Actuator destructor
+         *
+         * @details virtual as this class is a base class with virtual functions.
+        **/
         virtual ~Actuator(){}
 
-        /*
+        /**
          * @name    get_current_state
          *
          * @details accessor for the current state of the actuator. This includes current
          *          accelerations, velocities, and positions (if applicable).
          *
          * @returns the current state of the actuator
-         */
-        virtual actuator_state get_current_state(){} // MAY NEED TO REMOVE THIS OR CHANGE IT
+        **/
+        virtual actuator_state get_current_state(){} // May need to add a default implementation
 
-        /*
+        /**
          * @name    get_target_state
          *
          * @details accessor for the target state of the actuator.
          *
          * @returns the current target state of the actuator.
-         */
+        **/
         actuator_state get_target_state();
 
-        /*
+        /**
          * @name    set_target_state
          *
          * @details sets the target state the actuator is requesting from the simulation.
@@ -193,159 +219,192 @@ class Actuator : public ADCS_device
          *
          * @param   target_state the new state the control code would like to be in.
          *
-         */
+        **/
         virtual void set_target_state(actuator_state target_state){} // MAY NEED TO REMOVE THIS OR CHANGE IT
 
-        /*
+        /**
          * @name    get_position
          *
          * @details accessor for the position of the actuator.
          *
          * @returns the position within the satellite of the actuator.
-         */
+        **/
         Eigen::Vector3f get_position();
 
     protected:
-        /*
+        /**
          * @name    set_current_state
          *
          * @details sets the output values (acceleration, velocities, and position as applicable)
          *          of the actuator.
          *
-         * @param   new_value the new state of the actuator. This is set by the simulation.
-         */
+         * @param   new_state the new state of the actuator. This is set by the simulation.
+        **/
         void set_current_state(actuator_state new_state);
 
+        /**
+         * @name    check_valid_state
+         * 
+         * @details checks if the provided state is valid. 
+         * 
+         * @param state the state to check
+         * 
+         * @throws  ______ exception if the state is not valid. If no exception is thrown, it is 
+         *          valid.
+        **/
         void check_valid_state(actuator_state state);
 
+        // is this ever used?
+        /* Target state of the actuator. */
         actuator_state target_state;
 
-        /* The position in the satellite of the actuator. */
+        /* The position in the satellite of the actuator.**/
         Eigen::Vector3f position;
 
         /* Current acceleration values for each actuator*/
         actuator_state current_state;
     private:
-        /* The maximum value for each state property of the actuator. */
+        /* The maximum value for each state property of the actuator.**/
         actuator_state max_state_values;
 
-        /* The minimum value for each state property of the actuator. */
+        /* The minimum value for each state property of the actuator.**/
         actuator_state min_state_values;
 
 };
 
 /**************************************** CONCRETE CLASSES ***************************************/
 
-/*
+/**
  * @class adcs_timer
  *
  * @details this class defines all timing interactions.
  *
- */
+**/
 class ADCS_timer
 {
     public:
-        /*
+        /**
          * @name ADCS_timer constructor
          *
          * @details constructor for the ADCS_timer. Uses the simulator to get the actual time.
-         */
+        **/
         ADCS_timer(Simulator* sim);
 
-        /*
+        /**
          * @name get_time
          *
          * @returns the current time
-         */
+        **/
         timestamp get_time();
 
-        /*
+        /**
          * @name sleep
          *
          * @details sets the control code to sleep for a requested amount of time.
          *
          * @param time the amount of time to sleep
          *
-         */
+        **/
         timestamp sleep(timestamp duration);
 
     private:
-        /* Pointer to the simulation object, used to get the current time. */
+        /* Pointer to the simulation object, used to get the current time.**/
         Simulator* sim;
 };
 
-/*
+/**
  * @class accelerometer
  *
  * @details concrete Sensor implementation for accelerometers
  *
  * @implements ADCS_device, Sensor
- */
+**/
 class Accelerometer : public Sensor {
     public:
+        /**
+         * @name Accelerometer constructor
+         * 
+         * @details all values are directly passed to the Sensor base class. Number of sensors is
+         *          one, and the number of axes is 3.
+         * 
+         * @param polling_time  polling time of the sensor
+         * @param sim           simulator object used to update and get updates about the device
+         * @param positions     positions of all sensor locations on the satellite
+        */
         Accelerometer(timestamp polling_time, Simulator* sim, Eigen::Vector3f positions) : Sensor(polling_time, sim, {positions}, 1, 3) {}
 
-        /*
+        /**
          * @name    take_measurement
          *
          * @details this function takes a measurement using the sensor. The simulation is also told
          *          to update.
          *
          * @returns the required measurement if succesful.
-         */
+        **/
         measurement take_measurement();
 };
 
-/*
+/**
  * @class gyroscope
  *
  * @details concrete Sensor implementation for gyroscopes
  *
  * @implements ADCS_device, Sensor
- */
+**/
 class Gyroscope : public Sensor {
     public:
+        /**
+         * @name Gyroscope constructor
+         * 
+         * @details all values are directly passed to the Sensor base class. Number of sensors is
+         *          one, and the number of axes is 3.
+         * 
+         * @param polling_time  polling time of the sensor
+         * @param sim           simulator object used to update and get updates about the device
+         * @param positions     positions of all sensor locations on the satellite
+        */
         Gyroscope(timestamp polling_time, Simulator* sim, Eigen::Vector3f positions) : Sensor(polling_time, sim, {positions}, 1, 3) {}
 
-        /*
+        /**
          * @name    take_measurement
          *
          * @details this function takes a measurement using the sensor. The simulation is also told
          *          to update.
          *
          * @returns the required measurement if succesful.
-         */
+        **/
         measurement take_measurement();
 };
 
-/*
+/**
  * @class Reaction_wheel
  *
  * @details concrete Actuator implementation for reaction wheels
  *
  * @implements ADCS_device, Actuator
- */
+**/
 class Reaction_wheel : public Actuator
 {
     public:
-        /*
+        /**
          * @name Reaction_wheel constructor
          *
-         * @details constructor for the Reaction_wheel.
-         */
+         * @details constructor for the Reaction_wheel. All parameters are passed to the Actuator
+         *          base class.
+        **/
         Reaction_wheel(timestamp polling_time, Simulator* sim, Eigen::Vector3f position, actuator_state max_vals, actuator_state min_vals, Eigen::Matrix3f inertia_matrix);
 
-        /*
+        /**
          * @name    get_inertia_matrix
          *
          * @details inertia matrix accessor
          *
          * @returns the inertia matrix of a reaction wheel
          *
-         */
+        **/
         Eigen::Matrix3f get_inertia_matrix();
 
-        /*
+        /**
          * @name    set_target_state
          *
          * @details sets the target state the actuator is requesting from the simulation.
@@ -354,27 +413,27 @@ class Reaction_wheel : public Actuator
          *
          * @param   target_state the new state the control code would like to be in.
          *
-         */
+        **/
         void set_target_state(actuator_state target_state);
 
-        /*
+        /**
          * @name    get_current_state
          *
          * @details accessor for the current state of the actuator. This includes current
          *          accelerations, velocities, and positions (if applicable).
          *
          * @returns the current state of the actuator
-         */
+        **/
         actuator_state get_current_state();
 
     private:
 
-        /*
+        /**
          * @name    inertia_matrix
          *
          * @details inertia matrix for a reaction wheel. It is assumed that all reaction wheels
          *          have the same inertia matrix in their frame of reference.
-         */
+        **/
         Eigen::Matrix3f inertia_matrix;
 };
 

--- a/csdc-6/adcs-simulation/cpp/interface/inc/sim_interface.hpp
+++ b/csdc-6/adcs-simulation/cpp/interface/inc/sim_interface.hpp
@@ -125,7 +125,11 @@ class Sensor : public ADCS_device {
          *
          * @returns the required measurement if succesful.
         **/
-        virtual measurement take_measurement(){} // MAY need to create a default implementation
+        virtual measurement take_measurement() // MAY need to create a default implementation
+        {
+            measurement empty;
+            return empty;
+        } 
 
         /**
          * @name    set_current_vals
@@ -199,7 +203,11 @@ class Actuator : public ADCS_device
          *
          * @returns the current state of the actuator
         **/
-        virtual actuator_state get_current_state(){} // May need to add a default implementation
+        virtual actuator_state get_current_state() // May need to add a default implementation
+        {
+            actuator_state empty;
+            return empty;
+        }
 
         /**
          * @name    get_target_state
@@ -220,7 +228,11 @@ class Actuator : public ADCS_device
          * @param   target_state the new state the control code would like to be in.
          *
         **/
-        virtual void set_target_state(actuator_state target_state){} // MAY NEED TO REMOVE THIS OR CHANGE IT
+        virtual void set_target_state(actuator_state target_state)
+        {
+            this->target_state = target_state;
+            return;
+        } // MAY NEED TO REMOVE THIS OR CHANGE IT
 
         /**
          * @name    get_position

--- a/csdc-6/adcs-simulation/cpp/interface/src/ADCS_device.cpp
+++ b/csdc-6/adcs-simulation/cpp/interface/src/ADCS_device.cpp
@@ -1,12 +1,12 @@
-/** @file 	ADCS_device.hpp
+/** 
+ * @file 	ADCS_device.cpp
  *
- * @details This file defines the interface between the control code and the simulation. It expands
- *          interface.hpp by adding simulation specific functions as required to the interface.
+ * @details This file implements the ADCS_device class as defined in sim_interface.hpp
  *
  * @authors Aidan Sheedy
  *
  * Last Edited
- * 2022-10-11
+ * 2022-11-07
  *
 **/
 
@@ -19,7 +19,7 @@ ADCS_device::ADCS_device(timestamp polling_time, Simulator* sim) : min_polling_i
 {
 	if (NULL == sim)
 	{
-		/* THROW APPROPRIATE EXCEPTION */
+		/* THROW APPROPRIATE EXCEPTION**/
 	}
 
 	this->sim = sim;

--- a/csdc-6/adcs-simulation/cpp/interface/src/ADCS_timer.cpp
+++ b/csdc-6/adcs-simulation/cpp/interface/src/ADCS_timer.cpp
@@ -1,4 +1,5 @@
-/** @file   Sensor.hpp
+/** 
+ * @file    ADCS_timer.cpp
  *
  * @details This file implements the ADCS_timer class as defined in sim_interface.
  *
@@ -18,7 +19,7 @@ ADCS_timer::ADCS_timer(Simulator* sim)
 {
     if (NULL == sim)
     {
-        /* THROW EXCEPTION */
+        /* THROW EXCEPTION**/
     }
 
     this->sim = sim;

--- a/csdc-6/adcs-simulation/cpp/interface/src/Accelerometer.cpp
+++ b/csdc-6/adcs-simulation/cpp/interface/src/Accelerometer.cpp
@@ -1,11 +1,12 @@
-/** @file   Sensor.hpp
+/** 
+ * @file   Accelerometer.cpp
  *
- * @details This file implements the Sensor class as defined in sim_interface.
+ * @details This file implements the Accelerometer class as defined in sim_interface.
  *
  * @authors Aidan Sheedy
  *
  * Last Edited
- * 2022-10-11
+ * 2022-11-07
  *
 **/
 
@@ -17,7 +18,7 @@ measurement Accelerometer::take_measurement()
 {
     if (this->time_until_ready() > 0)
     {
-        /* THROW APPROPRIATE EXCEPTION */
+        /* THROW APPROPRIATE EXCEPTION**/
     }
 
     Eigen::Vector3f measurement;

--- a/csdc-6/adcs-simulation/cpp/interface/src/Actuator.cpp
+++ b/csdc-6/adcs-simulation/cpp/interface/src/Actuator.cpp
@@ -1,4 +1,5 @@
-/** @file Actuator.hpp
+/** 
+ * @file Actuator.hpp
  *
  * @details This file dimplements the Actuator class as defined in sim_interface.
  *
@@ -34,7 +35,7 @@ void Actuator::set_current_state(actuator_state new_state)
     }
     catch(const std::exception& e)
     {
-        /* THROW APPROPRIATE EXCEPTION */
+        /* THROW APPROPRIATE EXCEPTION**/
     }
 
     this->current_state = new_state;

--- a/csdc-6/adcs-simulation/cpp/interface/src/Gyroscope.cpp
+++ b/csdc-6/adcs-simulation/cpp/interface/src/Gyroscope.cpp
@@ -1,11 +1,12 @@
-/** @file   Sensor.hpp
+/** 
+ * @file   Gyroscope.cpp
  *
- * @details This file implements the Sensor class as defined in sim_interface.
+ * @details This file implements the Gyroscope class as defined in sim_interface.
  *
  * @authors Aidan Sheedy
  *
  * Last Edited
- * 2022-10-11
+ * 2022-11-07
  *
 **/
 
@@ -17,7 +18,7 @@ measurement Gyroscope::take_measurement()
 {
     if (this->time_until_ready() > 0)
     {
-        /* THROW APPROPRIATE EXCEPTION */
+        /* THROW APPROPRIATE EXCEPTION**/
     }
 
     Eigen::Vector3f measurement;

--- a/csdc-6/adcs-simulation/cpp/interface/src/Reaction_wheel.cpp
+++ b/csdc-6/adcs-simulation/cpp/interface/src/Reaction_wheel.cpp
@@ -1,12 +1,12 @@
-/** @file   Reaction_wheel
-.hpp
+/** 
+ * @file    Reaction_wheel.cpp
  *
  * @details This file implements the reaction wheel definition as defined in sim_interface.hpp.
  *
  * @authors Aidan Sheedy
  *
  * Last Edited
- * 2022-11-02
+ * 2022-11-07
  *
 **/
 
@@ -43,12 +43,12 @@ void Reaction_wheel::set_target_state(actuator_state new_target)
     }
     catch(const std::exception& e)
     {
-        /* THROW APPROPRIATE EXCEPTION */
+        /* THROW APPROPRIATE EXCEPTION**/
     }
 
     if (this->time_until_ready() > 0)
     {
-        /* THROW APPROPRIATE EXCEPTION */
+        /* THROW APPROPRIATE EXCEPTION**/
     }
 
     this->target_state = new_target;

--- a/csdc-6/adcs-simulation/cpp/interface/src/Sensor.cpp
+++ b/csdc-6/adcs-simulation/cpp/interface/src/Sensor.cpp
@@ -1,4 +1,5 @@
-/** @file   Sensor.hpp
+/** 
+ * @file   Sensor.hpp
  *
  * @details This file implements the Sensor class as defined in sim_interface.
  *
@@ -16,14 +17,14 @@ Sensor::Sensor(timestamp polling_time, Simulator* sim, std::vector<Eigen::Vector
 {
     if (num_sensors != positions.size())
     {
-        /* THROW EXCEPTION */
+        /* THROW EXCEPTION**/
     }
 
     for (int i = 0; i < num_sensors; i++)
     {
         if (num_axes != positions.at(i).size())
         {
-            /* THROW EXCEPTION */
+            /* THROW EXCEPTION**/
         }
     }
 
@@ -41,7 +42,7 @@ void Sensor::set_current_vals(std::vector<Eigen::VectorXf> physical_vals, timest
         /* SETUP DOES NOT MEET ASSUMPTIONS - THROW EXCEPTION*/
     }
 
-    /* Default behaviour is to assume that the physical values require no modification. */
+    /* Default behaviour is to assume that the physical values require no modification.**/
     current_vector_value.time_taken = time;
     current_vector_value.vec = physical_vals.at(0);
 

--- a/csdc-6/adcs-simulation/cpp/interface/src/Sensor.cpp
+++ b/csdc-6/adcs-simulation/cpp/interface/src/Sensor.cpp
@@ -20,7 +20,7 @@ Sensor::Sensor(timestamp polling_time, Simulator* sim, std::vector<Eigen::Vector
         /* THROW EXCEPTION**/
     }
 
-    for (int i = 0; i < num_sensors; i++)
+    for (uint32_t i = 0; i < num_sensors; i++)
     {
         if (num_axes != positions.at(i).size())
         {

--- a/csdc-6/adcs-simulation/cpp/src/Messenger.cpp
+++ b/csdc-6/adcs-simulation/cpp/src/Messenger.cpp
@@ -1,18 +1,12 @@
 /**
  * @file    Messenger.cpp
  *
- * @details This file describes the UI implementation. For now this is a simple command line UI
- *          with three commands:
- *              - "start_sim" starts a new simulation run with an initial state and desired output
- *                 configuration files
- *              - "restart_sim" resumes where the previous run left off but, but with a new desired
- *                 output configuration file
- *              - "exit" closes the terminal and ends the session
+ * @details This file implements the Messenger class as defined in Messenger.hpp.
  *
  * @authors Aidan Sheedy
  *
  * Last Edited
- * 2022-11-05
+ * 2022-11-07
  *
 **/
 

--- a/csdc-6/adcs-simulation/cpp/src/Messenger.cpp
+++ b/csdc-6/adcs-simulation/cpp/src/Messenger.cpp
@@ -10,8 +10,6 @@
  *
 **/
 
-#pragma once
-
 #include <string>
 #include <iostream>
 

--- a/csdc-6/adcs-simulation/cpp/src/SensorActuatorFactory.cpp
+++ b/csdc-6/adcs-simulation/cpp/src/SensorActuatorFactory.cpp
@@ -1,12 +1,12 @@
 /**
- * @file Simulator.cpp
+ * @file    SensorActuatorFactory.cpp
  *
  * @details class file to create the sensor and actuator objects
  *
  * @authors Lily de Loe
  *
  * Last Edited
- * 2022-10-24
+ * 2022-11-07
  *
 **/
 
@@ -54,13 +54,13 @@ std::shared_ptr<Actuator> SensorActuatorFactory::GetActuator(const std::string &
             actuator_state min;
             min.acceleration = reac->minAngAccel;
             min.velocity = reac->minAngVel;
-            min.position = -100000000000000.0f;
+            min.position = -100000000000000.0f; // These should be set in the YAML
             min.time = timestamp(0.0f);
             actuator_state max;
             max.acceleration = reac->maxAngAccel;
             max.velocity = reac->maxAngVel;
-            max.position = 10000000000.0f;
-            max.time = timestamp(10000000.0f);
+            max.position = 10000000000.0f; // These should be set in the YAML
+            max.time = timestamp(10000000.0f); // These should be set in the YAML
             ret = std::make_shared<Reaction_wheel>(timestamp(reac->pollingTime), sim, reac->position, min, max, reac->momentOfInertia);
             break;
         }

--- a/csdc-6/adcs-simulation/cpp/src/Simulator.cpp
+++ b/csdc-6/adcs-simulation/cpp/src/Simulator.cpp
@@ -41,11 +41,15 @@ void Simulator::init(sim_config initial_values)
 timestamp Simulator::update_simulation() {
     timestamp time_passed = this->determine_time_passed();
     this->simulate(time_passed);
+
+    return this->simulation_time;
 }
 
 timestamp Simulator::set_adcs_sleep(timestamp duration) {
     timestamp time_passed = this->determine_time_passed();
     this->simulate(time_passed + duration);
+
+    return this->simulation_time;
 }
 
 timestamp Simulator::determine_time_passed() {

--- a/csdc-6/adcs-simulation/cpp/src/Simulator.cpp
+++ b/csdc-6/adcs-simulation/cpp/src/Simulator.cpp
@@ -1,12 +1,12 @@
 /**
  * @file Simulator.cpp
  *
- * @details class file that would configure and propagate the simulation
+ * @details implements the Simulator class as defined in Simulator.hpp
  *
- * @authors Lily de Loe, Justin Paoli
+ * @authors Lily de Loe, Justin Paoli, Aidan Sheedy
  *
  * Last Edited
- * 2022-11-04
+ * 2022-11-07
  *
 **/
 
@@ -34,7 +34,7 @@ Simulator::Simulator(Messenger *messenger)
 
 void Simulator::init(sim_config initial_values)
 {
-    /* TODO may need a check here */
+    /* TODO may need a check here**/
     this->system_vals = initial_values;
 }
 

--- a/csdc-6/adcs-simulation/cpp/src/UI.cpp
+++ b/csdc-6/adcs-simulation/cpp/src/UI.cpp
@@ -13,7 +13,7 @@
 #include <string>
 #include <vector>
 #include <any>
-#include <iostream>
+#include <iostream> 
 
 #include "UI.hpp"
 #include "Simulator.hpp"
@@ -34,10 +34,10 @@ void UI::start_ui_loop()
     this->terminal_active = true;
     messenger.prompt_char();
 
-    /*
+    /**
      * For now terminal_active remains true. Future commands may change the flag to false to break
      * from the loop gracefully.
-     */
+    **/
     while (terminal_active)
     {
         // get user input
@@ -129,10 +129,10 @@ void UI::run_simulation(std::vector<std::string> args)
     std::string config_yaml = args.at(1);
     // string exit_conditions_yaml = args.at(2);
 
-    /* Empty simulator */
+    /* Empty simulator**/
     Simulator simulator(&messenger);
 
-    /* Initialize Interface Objects */
+    /* Initialize Interface Objects**/
     std::unordered_map<std::string, std::shared_ptr<Sensor>> sensors;
     std::unordered_map<std::string, std::shared_ptr<Actuator>> actuators;
 
@@ -143,7 +143,7 @@ void UI::run_simulation(std::vector<std::string> args)
         // std::cout <<"Configuration Failed to load"<< std::endl;
     }
 
-    /* Get Simulation config info */
+    /* Get Simulation config info**/
     simulator.init(this->get_sim_config(config));
 
     for (const auto &sensor : config.GetSensorConfigs())
@@ -157,38 +157,20 @@ void UI::run_simulation(std::vector<std::string> args)
         this->create_actuator(actuator.first, &simulator, &actuators);
     }
 
-    /* Start control code */
+    /* Start control code**/
     PointingModeController controller(sensors, actuators);
 
     controller.begin({0}); // Empty desired attitude for now
 
-    /*
-     * We can check for the file path existing here, but it is a race condition. The simulator
-     * should check it when it opens it and will return an exception, we can have a simple check
-     * for an "invalid file path" exception when instantiating the simulator, which is probably a
-     * better way of doing it.
-     */
-
-    // add try catch for above problem?
-
+    /* This code should not be deleted - it will be necessary when the final_state_yaml is implemented.**/
     // string final_state_yaml_path;
-
-    /*
-     * In init, simulator should create a Control code class that has all of the sensors and
-     * actuators. Then, this function should call simulator with a function like:
-     */
-
-    /*
-     * Again when passing the exit_conditions_yaml there's a possibility that it is an invalid
-     * path. Same problem arises with it being a race condition though.
-     */
 
     // if (!final_state_yaml_path.empty())
     // {
     //     /* TODO this could also check if the yaml is a valid path, but race condition again. Still,
     //      * in this case it is probably worth checking because there's no point in saving it as a
     //      * variable if it's invalid to start with.
-    //      */
+    //     **/
     //     this->previous_end_state_yaml = final_state_yaml_path;
     // }
 
@@ -287,7 +269,7 @@ void UI::resume_simulation(std::vector<std::string> args)
         }
     }
 
-    /* Use previous final state yaml as new initial state */
+    /* Use previous final state yaml as new initial state**/
     std::vector<std::string> new_args = {
         "unused",
         this->previous_end_state_yaml,

--- a/csdc-6/adcs-simulation/cpp/src/UI.cpp
+++ b/csdc-6/adcs-simulation/cpp/src/UI.cpp
@@ -88,7 +88,7 @@ void UI::run_command(std::vector<std::string> args)
             // (this->*command)(args); // code in modern C++
             command(args);
         }
-        catch(invalid_ui_args e)
+        catch(invalid_ui_args& e)
         {
             messenger.send_warning(e.what());
         }

--- a/csdc-6/adcs-simulation/cpp/src/main.cpp
+++ b/csdc-6/adcs-simulation/cpp/src/main.cpp
@@ -3,10 +3,10 @@
  *
  * @details main file to control the adcs simulator
  *
- * @authors Lily de Loe
+ * @authors Lily de Loe, Aidan Sheedy
  *
  * Last Edited
- * 2022-10-24
+ * 2022-11-07
  *
 **/
 
@@ -16,7 +16,6 @@
 
 int main(int argc, char **argv) {
     UI ui;
-
     ui.start_ui_loop();
     return 0;
 }

--- a/csdc-6/adcs-simulation/cpp/src/main.cpp
+++ b/csdc-6/adcs-simulation/cpp/src/main.cpp
@@ -14,7 +14,7 @@
 
 #include "UI.hpp"
 
-int main(int argc, char **argv) {
+int main([[maybe_unused]] int argc, [[maybe_unused]] char **argv) {
     UI ui;
     ui.start_ui_loop();
     return 0;


### PR DESCRIPTION
Summary of both commits:

CHANGES
- Fixed timestamps "pretty_string" function
- Updated missing or incorrect block comments in most classes
- Cleaned up unnecessary empty "class Simulator" statements
- ixed all compiler errors. List is as follows:
1. Added [[maybe_unused]] to argc and **argv in main. These may be used
   later, but since they are required params for the main function this
   is the only option unless we end up using them.
2. Upadted all "catch" expressions to catch the exception by address,
   not value
3. Added return lines to functions missing a return
4. Removed #pragma once from cpp files
5. Removed unnecessary int to uint casting
6. Added lines to use unused parameters if necessary (some of these may
   need future improvements)
7. Updated all exceptions to use "const char*" instead of "char*"
   parameters