### PR TITLE
adcs-66 - update yaml and related functionality

### DIFF
--- a/csdc-6/adcs-simulation/cpp/inc/CommonStructs.hpp
+++ b/csdc-6/adcs-simulation/cpp/inc/CommonStructs.hpp
@@ -6,7 +6,7 @@
  * @authors Lily de Loe, Aidan Sheedy
  *
  * Last Edited
- * 2022-11-07
+ * 2022-11-08
  *
 **/
 #pragma once
@@ -34,7 +34,7 @@ enum class ActuatorType{
 * @property theta_b [Eigen::Vector3f], the angular position of the satellite body
 * @property omega_b [Eigen::Vector3f], the angular velocity of the satellite body
 * @property alpha_b [Eigen::Vector3f], the angular acceleration of the satellite body
-* @properft inertia_b [Eigen::Matrix3f], the inertia tensor of the satellite body
+* @property inertia_b [Eigen::Matrix3f], the inertia tensor of the satellite body
 *
 * @details A model of the values controlling the rotational kinematics of the
 * satellite. Used internally by the simulator to keep track of the satellite
@@ -63,7 +63,7 @@ typedef struct
 {
     Eigen::Vector3f omega;
     Eigen::Vector3f alpha;
-    Eigen::Matrix3f inertia;
+    float inertia;
     Eigen::Vector3f position;
 } sim_reaction_wheel;
 

--- a/csdc-6/adcs-simulation/cpp/inc/ConfigurationSingleton.hpp
+++ b/csdc-6/adcs-simulation/cpp/inc/ConfigurationSingleton.hpp
@@ -90,8 +90,7 @@ struct AccelerometerConfig : public SensorConfig {
 */
 struct ReactionWheelConfig : public ActuatorConfig {
     ReactionWheelConfig(const YAML::Node &node);
-
-    //Eigen::Matrix3f momentOfInertia;
+    
     float momentOfInertia;
     float maxAngVel;
     float maxAngAccel;

--- a/csdc-6/adcs-simulation/cpp/inc/ConfigurationSingleton.hpp
+++ b/csdc-6/adcs-simulation/cpp/inc/ConfigurationSingleton.hpp
@@ -6,7 +6,7 @@
  * @authors Lily de Loe
  *
  * Last Edited
- * 2022-11-03
+ * 2022-11-08
  *
 **/
 
@@ -28,10 +28,10 @@
 */
 struct SensorConfig {
     SensorConfig(SensorType t, const YAML::Node &node) : type(t){
-        pollingTime = node["PollingTime"].as<double>();
+        pollingTime = node["PollingTime"].as<float>();
         int j = 0;
         for (const auto &n : node["Position"]) {
-            position(j++) = n.as<double>();
+            position(j++) = n.as<float>();
         }
     };
     virtual ~SensorConfig() = default;
@@ -55,8 +55,6 @@ struct ActuatorConfig {
 
 /**
 * @name GryoConfig
-* @property pollingTime [float] the polling time of the gyroscope
-* @property position [Eigen::Matrix3f] the position of the sensor
 *
 * @details struct outling the configuration of a gryoscope according to the input YAML
 * parameters
@@ -68,8 +66,6 @@ struct GyroConfig : public SensorConfig {
 
 /**
 * @name AccelerometerConfig
-* @property pollingTime [float] the polling time of the accelerometer
-* @property position [Eigen::Matrix3f] the position of the sensor
 *
 * @details struct outling the configuration of an accelerometer according to the input YAML
 * parameters
@@ -95,7 +91,8 @@ struct AccelerometerConfig : public SensorConfig {
 struct ReactionWheelConfig : public ActuatorConfig {
     ReactionWheelConfig(const YAML::Node &node);
 
-    Eigen::Matrix3f momentOfInertia;
+    //Eigen::Matrix3f momentOfInertia;
+    float momentOfInertia;
     float maxAngVel;
     float maxAngAccel;
     float minAngVel;
@@ -213,6 +210,16 @@ public:
         return satelliteVelocity;
     };
 
+    /**
+    * @name GetTimestepInMilliSeconds
+    * @return the timestep, in seconds, as a float
+    * 
+    * @details getter for the update timestep 
+    */
+    inline const float &GetTimestepInMilliSeconds(){
+        return timestepInMilliSeconds;
+    }
+
 
 private:
     /**
@@ -222,33 +229,40 @@ private:
     Configuration(){};
 
 private:
+    
     /**
     * @details YAML node for the top-most heading in the YAML input file
-   **/
+    **/
     YAML::Node top;
 
     /**
     * @details unordered map of sensor configs that relates strings to names
-   **/
+    **/
     std::unordered_map<std::string, std::shared_ptr<SensorConfig>> sensorConfigs;
 
     /**
     * @details unordered map of actuator configs that relates strings to names
-   **/
+    **/
     std::unordered_map<std::string, std::shared_ptr<ActuatorConfig>> actuatorConfigs;
 
     /**
     * @details 3-dimensional matrix storing the satellite's moment of inertia
-   **/
+    **/
     Eigen::Matrix3f satelliteMomentOfInertia;
 
     /**
     * @details 3-dimensional vector storing the satellite's position
-   **/
+    **/
     Eigen::Vector3f satellitePosition;
 
     /**
     * @details 3-dimensional matrix storing the satellite's velocity
-   **/
+    **/
     Eigen::Vector3f satelliteVelocity;
+
+    /**
+     * @details float storing the timestep in milliseconds
+    */
+    float timestepInMilliSeconds;
+
 };

--- a/csdc-6/adcs-simulation/cpp/interface/inc/sim_interface.hpp
+++ b/csdc-6/adcs-simulation/cpp/interface/inc/sim_interface.hpp
@@ -448,7 +448,6 @@ class Reaction_wheel : public Actuator
          *          have the same inertia matrix in their frame of reference.
         **/
         float inertia_matrix;
-        //Eigen::Matrix3f inertia_matrix;
 };
 
 #endif

--- a/csdc-6/adcs-simulation/cpp/interface/inc/sim_interface.hpp
+++ b/csdc-6/adcs-simulation/cpp/interface/inc/sim_interface.hpp
@@ -415,7 +415,6 @@ class Reaction_wheel : public Actuator
          *
         **/
         float get_inertia_matrix();
-        //Eigen::Matrix3f get_inertia_matrix();
 
         /**
          * @name    set_target_state

--- a/csdc-6/adcs-simulation/cpp/interface/inc/sim_interface.hpp
+++ b/csdc-6/adcs-simulation/cpp/interface/inc/sim_interface.hpp
@@ -3,10 +3,10 @@
  * @details This file defines the interface between the control code and the simulation. It expands
  *          interface.hpp by adding simulation specific functions as required to the interface.
  *
- * @authors Aidan Sheedy
+ * @authors Aidan Sheedy, Lily de Loe
  *
  * Last Edited
- * 2022-11-07
+ * 2022-11-08
  *
 **/
 #include <vector>
@@ -404,7 +404,7 @@ class Reaction_wheel : public Actuator
          * @details constructor for the Reaction_wheel. All parameters are passed to the Actuator
          *          base class.
         **/
-        Reaction_wheel(timestamp polling_time, Simulator* sim, Eigen::Vector3f position, actuator_state max_vals, actuator_state min_vals, Eigen::Matrix3f inertia_matrix);
+        Reaction_wheel(timestamp polling_time, Simulator* sim, Eigen::Vector3f position, actuator_state max_vals, actuator_state min_vals, float inertia_matrix);
 
         /**
          * @name    get_inertia_matrix
@@ -414,7 +414,8 @@ class Reaction_wheel : public Actuator
          * @returns the inertia matrix of a reaction wheel
          *
         **/
-        Eigen::Matrix3f get_inertia_matrix();
+        float get_inertia_matrix();
+        //Eigen::Matrix3f get_inertia_matrix();
 
         /**
          * @name    set_target_state
@@ -446,7 +447,8 @@ class Reaction_wheel : public Actuator
          * @details inertia matrix for a reaction wheel. It is assumed that all reaction wheels
          *          have the same inertia matrix in their frame of reference.
         **/
-        Eigen::Matrix3f inertia_matrix;
+        float inertia_matrix;
+        //Eigen::Matrix3f inertia_matrix;
 };
 
 #endif

--- a/csdc-6/adcs-simulation/cpp/interface/src/Reaction_wheel.cpp
+++ b/csdc-6/adcs-simulation/cpp/interface/src/Reaction_wheel.cpp
@@ -6,7 +6,7 @@
  * @authors Aidan Sheedy
  *
  * Last Edited
- * 2022-11-07
+ * 2022-11-08
  *
 **/
 
@@ -16,13 +16,12 @@
 #include "sim_interface.hpp"
 #include "Simulator.hpp"
 
-Reaction_wheel::Reaction_wheel(timestamp polling_time, Simulator* sim, Eigen::Vector3f position, actuator_state max_vals, actuator_state min_vals, Eigen::Matrix3f inertia_matrix) : Actuator(polling_time, sim, {position}, max_vals, min_vals)
+Reaction_wheel::Reaction_wheel(timestamp polling_time, Simulator* sim, Eigen::Vector3f position, actuator_state max_vals, actuator_state min_vals, float inertia_matrix) : Actuator(polling_time, sim, {position}, max_vals, min_vals)
 {
-    if (Eigen::Matrix3f::Zero() == inertia_matrix)
+
+    if(inertia_matrix == 0)
     {
         std::cout << "YEEEET" << std::endl;
-        throw -1;
-        // throw exception
     }
 
     this->inertia_matrix = inertia_matrix;
@@ -30,7 +29,7 @@ Reaction_wheel::Reaction_wheel(timestamp polling_time, Simulator* sim, Eigen::Ve
     return;
 }
 
-Eigen::Matrix3f Reaction_wheel::get_inertia_matrix()
+float Reaction_wheel::get_inertia_matrix()
 {
     return this->inertia_matrix;
 }

--- a/csdc-6/adcs-simulation/cpp/simulator.yaml
+++ b/csdc-6/adcs-simulation/cpp/simulator.yaml
@@ -12,16 +12,16 @@
 #   Position: [3-dimensional vector]
 #   Velcoity: [3-dimensional vector]
 Satellite:
-  Moment: [[1,0,0],
-           [0,1,0],
-           [0,0,1]]
-  Position: [1,2,3]
-  Velocity: [1,2,3]
+  Moment: [[0.02035470141,0.00004983389,0.00021768132],
+           [0.00004983389,0.01993812272,-0.00007588037],
+           [0.00021768132,-0.00007588037,0.0053506098]]
+  Position: [1,1,1]
+  Velocity: [10,10,10]
 
 # Actuators:
 #   Name: [name of actuator]
 #     type: [actuator type], ReactionWheel
-#     Moment: [3-dimensional matrix]
+#     Moment: [float]
 #     MaxAngVel: [float]
 #     MaxAngAccel: [float]
 #     MinAngVel: [float]
@@ -31,38 +31,40 @@ Satellite:
 Actuators:
   ReactionWheel1:
     type: ReactionWheel
-    Moment: [[1,0,0],
-             [0,1,0],
-             [0,0,1]]
+    Moment: 0.00000925
     MaxAngVel: 88
     MaxAngAccel: 8
     MinAngVel: 0
     MinAngAccel: 0
     PollingTime: 10
-    Position: [1,2,3]
+    Position: [1.73205080757,1.73205080757,-1.73205080757]
   ReactionWheel2:
     type: ReactionWheel
-    Moment: [[1,2,3],
-             [4,5,6],
-             [7,8,9]]
+    Moment: 0.00000925
     MaxAngVel: 88
     MaxAngAccel: 8
     MinAngVel: 0
     MinAngAccel: 0
     PollingTime: 10
-    Position: [1,2,3]
+    Position: [1.73205080757,-1.73205080757,-1.73205080757]
   ReactionWheel3:
     type: ReactionWheel
-    Moment: [[1,2,3],
-             [4,5,6],
-             [7,8,9]]
+    Moment: 0.00000925
     MaxAngVel: 88
     MaxAngAccel: 8
     MinAngVel: 0
     MinAngAccel: 0
     PollingTime: 10
-    Position: [1,2,3]
-
+    Position: [-1.73205080757,-1.73205080757,-1.73205080757]
+  ReactionWheel4:
+    type: ReactionWheel
+    Moment: 0.00000925
+    MaxAngVel: 88
+    MaxAngAccel: 8
+    MinAngVel: 0
+    MinAngAccel: 0
+    PollingTime: 10
+    Position: [-1.73205080757,1.73205080757,-1.73205080757]
 # Sensors:
 #   Name: [name of sensor]
 #     type: [sensor type], Gyroscope, Accelerometer
@@ -72,11 +74,11 @@ Sensors:
   Gyro1:
     type: Gyroscope
     PollingTime: 10
-    Position: [1,2,3]
+    Position: [1,1,1]
   Accel1:
     type: Accelerometer
     PollingTime: 10
-    Position: [1,2,3]
+    Position: [1,1,1]
 
 # Timestep: [float]
-TimeStep: 0.0001
+TimeStep: 1

--- a/csdc-6/adcs-simulation/cpp/src/ConfigurationSingleton.cpp
+++ b/csdc-6/adcs-simulation/cpp/src/ConfigurationSingleton.cpp
@@ -6,7 +6,7 @@
  * @authors Lily de Loe
  *
  * Last Edited
- * 2022-11-03
+ * 2022-11-08
  *
 **/
 
@@ -22,26 +22,18 @@ AccelerometerConfig::AccelerometerConfig(const YAML::Node &node) : SensorConfig(
 }
 
 ReactionWheelConfig::ReactionWheelConfig(const YAML::Node &node) : ActuatorConfig(ActuatorType::ReactionWheel) {
+    momentOfInertia = node["Moment"].as<float>();
+
+    maxAngVel = node["MaxAngVel"].as<float>();
+    maxAngAccel = node["MaxAngAccel"].as<float>();
+    minAngVel = node["MinAngVel"].as<float>();
+    minAngAccel = node["MinAngAccel"].as<float>();
+
+    pollingTime = node["PollingTime"].as<float>();
+
     int i = 0;
-    int j = 0;
-    for (const auto &n : node["Moment"]) {
-        j = 0;
-        for (const auto &a : n) {
-            momentOfInertia(i, j++) = a.as<double>();
-        }
-        ++i;
-    }
-
-    maxAngVel = node["MaxAngVel"].as<double>();
-    maxAngAccel = node["MaxAngAccel"].as<double>();
-    minAngVel = node["MinAngVel"].as<double>();
-    minAngAccel = node["MinAngAccel"].as<double>();
-
-    pollingTime = node["PollingTime"].as<double>();
-
-    i = 0;
     for (const auto &n : node["Position"]) {
-        position(i++) = n.as<double>();
+        position(i++) = n.as<float>();
     }
 }
 
@@ -62,23 +54,31 @@ bool Configuration::Load(const std::string &configFile) {
         for (const auto &n : satellite["Moment"]) {
             j = 0;
             for (const auto &a : n) {
-                satelliteMomentOfInertia(i, j++) = a.as<double>();
+                satelliteMomentOfInertia(i, j++) = a.as<float>();
             }
             ++i;
         }
 
         i = 0;
         for (const auto &n : satellite["Position"]) {
-            satellitePosition(i++) = n.as<double>();
+            satellitePosition(i++) = n.as<float>();
         }
 
         i = 0;
         for (const auto &n : satellite["Velocity"]) {
-            satelliteVelocity(i++) = n.as<double>();
+            satelliteVelocity(i++) = n.as<float>();
         }
 
     } catch (YAML::Exception &e){
         std::cout << "YAML ERROR ON SATELLITE STATE: " << e.what() <<std::endl;
+    }
+
+    //load input timestep
+    try {
+        YAML::Node time = top["TimeStep"];
+        timestepInMilliSeconds = time.as<float>();
+    } catch (YAML::Exception &e){
+        std::cout << "YAML ERROR ON TIMESTEP: " << e.what() <<std::endl;
     }
 
     //load sensors

--- a/csdc-6/adcs-simulation/cpp/src/SensorActuatorFactory.cpp
+++ b/csdc-6/adcs-simulation/cpp/src/SensorActuatorFactory.cpp
@@ -6,7 +6,7 @@
  * @authors Lily de Loe
  *
  * Last Edited
- * 2022-11-07
+ * 2022-11-08
  *
 **/
 
@@ -14,6 +14,7 @@
 #include "SensorActuatorFactory.hpp"
 #include "ConfigurationSingleton.hpp"
 #include "Simulator.hpp"
+#include <iostream>
 
 std::shared_ptr<Sensor> SensorActuatorFactory::GetSensor(const std::string &name, Simulator* sim) {
     auto &config = Configuration::GetInstance();
@@ -54,13 +55,13 @@ std::shared_ptr<Actuator> SensorActuatorFactory::GetActuator(const std::string &
             actuator_state min;
             min.acceleration = reac->minAngAccel;
             min.velocity = reac->minAngVel;
-            min.position = -100000000000000.0f; // These should be set in the YAML
+            min.position = -std::numeric_limits<float>::max();
             min.time = timestamp(0.0f);
             actuator_state max;
             max.acceleration = reac->maxAngAccel;
             max.velocity = reac->maxAngVel;
-            max.position = 10000000000.0f; // These should be set in the YAML
-            max.time = timestamp(10000000.0f); // These should be set in the YAML
+            max.position = std::numeric_limits<float>::max();
+            max.time = timestamp(std::numeric_limits<float>::max());
             ret = std::make_shared<Reaction_wheel>(timestamp(reac->pollingTime), sim, reac->position, min, max, reac->momentOfInertia);
             break;
         }

--- a/csdc-6/adcs-simulation/cpp/src/Simulator.cpp
+++ b/csdc-6/adcs-simulation/cpp/src/Simulator.cpp
@@ -6,7 +6,7 @@
  * @authors Lily de Loe, Justin Paoli, Aidan Sheedy
  *
  * Last Edited
- * 2022-11-07
+ * 2022-11-08
  *
 **/
 
@@ -27,7 +27,8 @@ Simulator::Simulator(Messenger *messenger)
 
     this->simulation_time = 0;
     // TODO: should be configured in YAML
-    timestamp t(1, 0);
+    auto &config = Configuration::GetInstance();
+    timestamp t(config.GetTimestepInMilliSeconds(),0);
     this->timestep_length = t;
     this->last_called = -1;
 }

--- a/csdc-6/adcs-simulation/cpp/src/UI.cpp
+++ b/csdc-6/adcs-simulation/cpp/src/UI.cpp
@@ -3,10 +3,10 @@
  *
  * @details This file implements the UI class as defined in UI.hpp
  *
- * @authors Aidan Sheedy
+ * @authors Aidan Sheedy, Lily de Loe
  *
  * Last Edited
- * 2022-11-05
+ * 2022-11-08
  *
 **/
 
@@ -127,6 +127,12 @@ void UI::run_simulation(std::vector<std::string> args)
     }
 
     std::string config_yaml = args.at(1);
+
+    Configuration &config = Configuration::GetInstance();
+    if (!config.Load(config_yaml))
+    {
+        std::cout <<"Configuration Failed to load"<< std::endl;
+    }
     // string exit_conditions_yaml = args.at(2);
 
     /* Empty simulator**/
@@ -135,13 +141,6 @@ void UI::run_simulation(std::vector<std::string> args)
     /* Initialize Interface Objects**/
     std::unordered_map<std::string, std::shared_ptr<Sensor>> sensors;
     std::unordered_map<std::string, std::shared_ptr<Actuator>> actuators;
-
-    Configuration &config = Configuration::GetInstance();
-
-    if (!config.Load(config_yaml))
-    {
-        // std::cout <<"Configuration Failed to load"<< std::endl;
-    }
 
     /* Get Simulation config info**/
     simulator.init(this->get_sim_config(config));


### PR DESCRIPTION
CHANGES
-reaction wheel: set min/max position and time to the limits for floats 
-simulator.yaml: updated the reaction wheel moment of inertia (matrix->scalar) 
-simulator now uses the timestep that's currently being specified in simulator.yaml 
-included four reaction wheels
-standardized the use of floats throughout (removed the use of double)

REASON
Revisions were made to the inputs to the mathematical model. The yaml file and relevant classes needed to be updated.

TESTING
Compiled code, ran simulation with current yaml. Numbers appear to obey physics.

GITHUB LINK
#66

Signed-off-by: Lily de Loe