### PR TITLE
adcs-66 - add csv functionality

### DIFF
--- a/csdc-6/.gitignore
+++ b/csdc-6/.gitignore
@@ -1,8 +1,9 @@
 /adcs-simulation/python/interface/build
 .vscode
-*/build
-*/CMakeFiles
-*/CMakeCache.txt
-*/Makefile
-*/bin
-.cmake
+build/
+CMakeFiles/
+CMakeCache.txt
+Makefile
+bin/
+output/
+cmake_install.cmake

--- a/csdc-6/adcs-simulation/cpp/cmake.sh
+++ b/csdc-6/adcs-simulation/cpp/cmake.sh
@@ -32,5 +32,5 @@ fi
 
 if [[ "$1" != "clean" ]]
 then
-    cmake .
+    cmake . -Wno-dev
 fi

--- a/csdc-6/adcs-simulation/cpp/inc/Messenger.hpp
+++ b/csdc-6/adcs-simulation/cpp/inc/Messenger.hpp
@@ -112,7 +112,7 @@ class Messenger
          * 
          * @param num_reaction_wheels number of reaction wheels in the run, used for the header.
         **/
-        void start_new_sim(int num_reaction_wheels);
+        void start_new_sim(uint32_t num_reaction_wheels);
 
         /**
          * @name    clean_csv_files
@@ -128,6 +128,10 @@ class Messenger
          * @details appends a simulation state to the end of the csv output file.
         **/
         void append_csv_output(sim_config state, timestamp time);
+
+        void write_cout_header(uint32_t num_reaction_wheels);
+
+        void write_csv_header(uint32_t num_reaction_wheels);
 
     private:
         /* Character used to denote user control of the terminal.**/

--- a/csdc-6/adcs-simulation/cpp/inc/Messenger.hpp
+++ b/csdc-6/adcs-simulation/cpp/inc/Messenger.hpp
@@ -32,10 +32,11 @@
 **/
 static const struct
 {
-    std::string reset  = "\033[0m";
-    std::string red    = "\033[31m";
-    std::string green  = "\033[32m";
-    std::string yellow = "\033[33m";
+    std::string reset   = "\033[0m";
+    std::string red     = "\033[31m";
+    std::string green   = "\033[32m";
+    std::string yellow  = "\033[33m";
+    std::string magenta = "\033[35m";
 } text_colour;
 
 /**
@@ -68,6 +69,16 @@ class Messenger
         void send_warning(std::string msg);
 
         /**
+         * @name    send_error
+         *
+         * @details Function used by all internal processes and commands to send errors to the
+         *          UI. Uniformily formats the messages for consistency and clarity.
+         *
+         * @param msg error to display to the user.
+        **/
+        void send_error(std::string msg);
+
+        /**
          * @name    update_simulation_state
          *
          * @details Function used by the simulation to udpate the user on the state of the system
@@ -81,18 +92,58 @@ class Messenger
          *              acceleration.
          * @param time  time of the update.
         **/
-        void update_simulation_state(Satellite state, timestamp time);
+        void update_simulation_state(sim_config state, timestamp time);
 
         /**
          * @name    prompt_char
          *
          * @details Function to tell the messenger to print the prompt cahracter.
         **/
-        void prompt_char();
+        inline void prompt_char()
+        {
+            std::cout << text_colour.reset << prompt_character;
+        }
+
+        /**
+         * @name    start_new_sim
+         *
+         * @details prints a header with columns for each simulation property, and starts a csv
+         *          file with the same header information.
+         * 
+         * @param num_reaction_wheels number of reaction wheels in the run, used for the header.
+        **/
+        void start_new_sim(int num_reaction_wheels);
+
+        /**
+         * @name    clean_csv_files
+         *
+         * @details clears the output directory of all files.
+        **/
+        void clean_csv_files();
+
+    private:
+        /**
+         * @name    append_csv_output
+         *
+         * @details appends a simulation state to the end of the csv output file.
+        **/
+        void append_csv_output(sim_config state, timestamp time);
 
     private:
         /* Character used to denote user control of the terminal.**/
         const std::string prompt_character = ">";
+
+        /* Default csv file path */
+        const std::string default_csv_path = "./output/";
+
+        /* default name of the output file */
+        const std::string default_csv_name = "sim_out";
+
+        /* extension of csv files */
+        const std::string csv_ext = ".csv";
+
+        /* full string of the output path */
+        std::string output_file_path_string = "";
 
 };
 

--- a/csdc-6/adcs-simulation/cpp/inc/UI.hpp
+++ b/csdc-6/adcs-simulation/cpp/inc/UI.hpp
@@ -141,6 +141,9 @@ class UI
         **/
         void quit(std::vector<std::string> args);
 
+        void clean_out(std::vector<std::string> args);
+
+    private:
         /**
          * @typedef UI::*commandFunc
          *
@@ -166,6 +169,9 @@ class UI
 
         /* Number of expected args for the "exit" command**/
         const uint8_t num_exit_args = 1;
+
+        /* Number of expected args for the "exit" command**/
+        const uint8_t num_clean_out_args = 1;
 
         /* Path to the YAML file describing the final state of the previous simulation run.**/
         std::string previous_end_state_yaml;

--- a/csdc-6/adcs-simulation/cpp/inc/UI.hpp
+++ b/csdc-6/adcs-simulation/cpp/inc/UI.hpp
@@ -141,6 +141,14 @@ class UI
         **/
         void quit(std::vector<std::string> args);
 
+        /**
+         * @name    clean_out
+         *
+         * @details Cleans all output csv files
+         *
+         * @param args the user input arguments. Arguments are as follows:
+         *              args[0] command "clean_out"
+        **/
         void clean_out(std::vector<std::string> args);
 
     private:

--- a/csdc-6/adcs-simulation/cpp/src/Messenger.cpp
+++ b/csdc-6/adcs-simulation/cpp/src/Messenger.cpp
@@ -6,12 +6,15 @@
  * @authors Aidan Sheedy
  *
  * Last Edited
- * 2022-11-07
+ * 2022-11-09
  *
 **/
 
 #include <string>
 #include <iostream>
+#include <fstream>
+#include <filesystem>
+#include <tgmath.h>
 
 #include "Messenger.hpp"
 
@@ -28,7 +31,6 @@ void Messenger::send_message(std::string msg)
     return;
 }
 
-
 void Messenger::send_warning(std::string msg)
 {
     if (msg.empty())
@@ -42,20 +44,175 @@ void Messenger::send_warning(std::string msg)
     return;
 }
 
-void Messenger::update_simulation_state(Satellite state, timestamp time)
+void Messenger::send_error(std::string msg)
+{
+    if (msg.empty())
+    {
+        // This may need to be a different exception.
+        throw invalid_message("Warning to send to UI is empty.");
+    }
+
+    // This can be formatted nicely later.
+    std::cerr << text_colour.red << "ERROR: " << msg << text_colour.reset << std::endl;
+    return;
+}
+
+void Messenger::start_new_sim(int num_reaction_wheels)
+{
+    /* Determine output file name */
+    std::string csv_path = this->default_csv_path;
+    std::string suffix = "";
+    uint32_t suffix_num = 0;
+
+    if (!std::filesystem::exists(csv_path))
+    {
+        std::filesystem::create_directory(csv_path);
+    }
+
+    csv_path += this->default_csv_name;
+
+    /* search for file if it exists, increment if it does */
+    while(std::filesystem::exists(csv_path + suffix + this->csv_ext))
+    {
+        if (UINT32_MAX > suffix_num)
+        {
+            // throw exception
+        }
+        suffix_num++;
+        suffix = std::to_string(suffix_num);
+    }
+
+    this->output_file_path_string = csv_path + suffix + this->csv_ext;
+
+    /* Write cout header */
+    std::cout << text_colour.magenta << "Time" << "\t\t";
+    std::cout << "Sat tx, Sat ty, Sat tz;\t\t" << "Sat Ox, Sat Oy, Sat Oz;\t\t" << "Sat ax, Sat ay, Sat az;\t\t";
+    std::cout << "Accel x, Accel y, Accel z;\t" << "Gyro x, Gyro y, Gyro z;\t\t";
+    for (int i = 0; i < num_reaction_wheels; i++)
+    {
+        std::cout << "RW " << i+1 << " O, RW " << i+1 << " a;";
+        if (i < num_reaction_wheels - 1)
+        {
+            std::cout << "\t\t";
+        }
+    }
+    std::cout << text_colour.reset << std::endl;
+
+    /* Write CSV header */
+    std::ofstream output_file;
+    output_file.open(output_file_path_string);
+
+    if (output_file.is_open())
+    {
+        output_file << "Time,Satelite theta x,Satelite theta y,Satelite theta z,Satellite Omega x,Satellite Omega y,Satellite Omega z,";
+        output_file << "Satellite alpha x,Satellite alpha y,Satellite alpha z,Accelerometer x,Accelerometer y,Accelerometer z,Gyro x,Gyro y,Gyro z,";
+        for (int i = 0; i < num_reaction_wheels; i++)
+        {
+            output_file << "Reaction wheel " << i << " Omega,Reaction wheel " << i << " alpha,";
+        }
+        output_file << std::endl;
+
+        // Close file?
+        output_file.close();
+    }
+    else
+    {
+        send_error("Unable to open file " + output_file_path_string);
+    }
+}
+
+void Messenger::update_simulation_state(sim_config state, timestamp time)
 {
     // Do we need any checks on state?
 
     // for now just text dump - next step is graphs for each.
-    std::cout << text_colour.reset << time.pretty_string() << "\t";
-    std::cout << state.theta_b.x() << ", " << state.theta_b.y() << ", " << state.theta_b.z() << ";\t";
-    std::cout << state.omega_b.x() << ", " << state.omega_b.y() << ", " << state.omega_b.z() << ";\t";
-    std::cout << state.alpha_b.x() << ", " << state.alpha_b.y() << ", " << state.alpha_b.z() << std::endl;
+    std::cout << text_colour.reset << time.pretty_string() << "\t" << std::setprecision(4) << std::fixed;
+    std::cout << state.satellite.theta_b.x() << ", " << state.satellite.theta_b.y() << ", " << state.satellite.theta_b.z() << ";\t\t";
+    std::cout << state.satellite.omega_b.x() << ", " << state.satellite.omega_b.y() << ", " << state.satellite.omega_b.z() << ";\t";
+    std::cout << state.satellite.alpha_b.x() << ", " << state.satellite.alpha_b.y() << ", " << state.satellite.alpha_b.z() << ";\t";
+
+    std::cout << state.accelerometer.measurement.x() << ", " << state.accelerometer.measurement.y() << ", " << state.accelerometer.measurement.z() << ";\t";
+    std::cout << state.gyroscope.measurement.x()     << ", " << state.gyroscope.measurement.y()     << ", " << state.gyroscope.measurement.z() << ";";
+
+    for (uint32_t i = 0; i < state.reaction_wheels.size(); i++)
+    {
+        float abs_omega = sqrt( state.reaction_wheels.at(i).omega.x()*state.reaction_wheels.at(i).omega.x() + 
+                                state.reaction_wheels.at(i).omega.y()*state.reaction_wheels.at(i).omega.y() + 
+                                state.reaction_wheels.at(i).omega.z()*state.reaction_wheels.at(i).omega.z() );
+        float abs_alpha = sqrt( state.reaction_wheels.at(i).alpha.x()*state.reaction_wheels.at(i).alpha.x() + 
+                                state.reaction_wheels.at(i).alpha.y()*state.reaction_wheels.at(i).alpha.y() + 
+                                state.reaction_wheels.at(i).alpha.z()*state.reaction_wheels.at(i).alpha.z() );
+        
+        std::cout << "\t" << abs_omega << ", " << abs_alpha << ";";
+
+        if (i < state.reaction_wheels.size() - 1)
+        {
+            std::cout << "\t";
+        }
+    }
+    std::cout << std::endl;
+
+    this->append_csv_output(state, time);
 
     return;
 }
 
-void Messenger::prompt_char()
+void Messenger::append_csv_output(sim_config state, timestamp time)
 {
-    std::cout << text_colour.reset << prompt_character;
+    // Open file (assuming it's still valid)
+    std::ofstream output_file;
+
+    try
+    {
+        output_file.open(output_file_path_string, std::fstream::out | std::fstream::app);
+    }
+    catch(const std::ios_base::failure& e)
+    {
+        send_error(e.what());
+    }
+
+    if (output_file.is_open())
+    {
+        output_file << (float)time << ",";
+        output_file << state.satellite.theta_b.x() << "," << state.satellite.theta_b.y() << "," << state.satellite.theta_b.z() << ",";
+        output_file << state.satellite.omega_b.x() << "," << state.satellite.omega_b.y() << "," << state.satellite.omega_b.z() << ",";
+        output_file << state.satellite.alpha_b.x() << "," << state.satellite.alpha_b.y() << "," << state.satellite.alpha_b.z() << ",";
+
+        output_file << state.accelerometer.measurement.x() << "," << state.accelerometer.measurement.y() << "," << state.accelerometer.measurement.z() << ",";
+        output_file << state.gyroscope.measurement.x()     << "," << state.gyroscope.measurement.y()     << "," << state.gyroscope.measurement.z()     << ",";
+
+        for (uint32_t i = 0; i < state.reaction_wheels.size(); i++)
+        {
+            float abs_omega = sqrt( state.reaction_wheels.at(i).omega.x()*state.reaction_wheels.at(i).omega.x() + 
+                                    state.reaction_wheels.at(i).omega.y()*state.reaction_wheels.at(i).omega.y() + 
+                                    state.reaction_wheels.at(i).omega.z()*state.reaction_wheels.at(i).omega.z() );
+            float abs_alpha = sqrt( state.reaction_wheels.at(i).alpha.x()*state.reaction_wheels.at(i).alpha.x() + 
+                                    state.reaction_wheels.at(i).alpha.y()*state.reaction_wheels.at(i).alpha.y() + 
+                                    state.reaction_wheels.at(i).alpha.z()*state.reaction_wheels.at(i).alpha.z() );
+
+            output_file << abs_omega << "," << abs_alpha << ",";
+        }
+        output_file << std::endl;
+
+        // Close file
+        output_file.close();
+    }
+    else
+    {
+        send_error("Unable to open file " + output_file_path_string);
+    }
+    return;
+}
+
+void Messenger::clean_csv_files()
+{
+    if (std::filesystem::exists(default_csv_path))
+    {
+        std::filesystem::remove_all(default_csv_path);
+    }
+    else
+    {
+        send_message("Output files already clean.");
+    }
+    return;
 }

--- a/csdc-6/adcs-simulation/cpp/src/Messenger.cpp
+++ b/csdc-6/adcs-simulation/cpp/src/Messenger.cpp
@@ -49,15 +49,42 @@ void Messenger::send_error(std::string msg)
     if (msg.empty())
     {
         // This may need to be a different exception.
-        throw invalid_message("Warning to send to UI is empty.");
+        throw invalid_message("Error to send to UI is empty.");
     }
 
     // This can be formatted nicely later.
     std::cerr << text_colour.red << "ERROR: " << msg << text_colour.reset << std::endl;
+
     return;
 }
 
-void Messenger::start_new_sim(int num_reaction_wheels)
+void Messenger::start_new_sim(uint32_t num_reaction_wheels)
+{
+    write_cout_header(num_reaction_wheels);
+    write_csv_header(num_reaction_wheels);
+
+    return;
+}
+
+void Messenger::write_cout_header(uint32_t num_reaction_wheels)
+{
+    std::cout << text_colour.magenta << "Time" << "\t\t";
+    std::cout << "Sat tx, Sat ty, Sat tz;\t\t" << "Sat Ox, Sat Oy, Sat Oz;\t\t" << "Sat ax, Sat ay, Sat az;\t\t";
+    std::cout << "Accel x, Accel y, Accel z;\t" << "Gyro x, Gyro y, Gyro z;\t\t";
+    for (uint32_t i = 0; i < num_reaction_wheels; i++)
+    {
+        std::cout << "RW " << i+1 << " O, RW " << i+1 << " a;";
+        if (i < num_reaction_wheels - 1)
+        {
+            std::cout << "\t\t";
+        }
+    }
+    std::cout << text_colour.reset << std::endl;
+
+    return;
+}
+
+void Messenger::write_csv_header(uint32_t num_reaction_wheels)
 {
     /* Determine output file name */
     std::string csv_path = this->default_csv_path;
@@ -69,57 +96,43 @@ void Messenger::start_new_sim(int num_reaction_wheels)
         std::filesystem::create_directory(csv_path);
     }
 
-    csv_path += this->default_csv_name;
-
     /* search for file if it exists, increment if it does */
     while(std::filesystem::exists(csv_path + suffix + this->csv_ext))
     {
         if (UINT32_MAX > suffix_num)
         {
-            // throw exception
+            this->output_file_path_string = "-1";
+            send_error("Unable to create output CSV, too many files exist.");
         }
         suffix_num++;
         suffix = std::to_string(suffix_num);
     }
 
-    this->output_file_path_string = csv_path + suffix + this->csv_ext;
-
-    /* Write cout header */
-    std::cout << text_colour.magenta << "Time" << "\t\t";
-    std::cout << "Sat tx, Sat ty, Sat tz;\t\t" << "Sat Ox, Sat Oy, Sat Oz;\t\t" << "Sat ax, Sat ay, Sat az;\t\t";
-    std::cout << "Accel x, Accel y, Accel z;\t" << "Gyro x, Gyro y, Gyro z;\t\t";
-    for (int i = 0; i < num_reaction_wheels; i++)
+    if ("-1" != this->output_file_path_string)
     {
-        std::cout << "RW " << i+1 << " O, RW " << i+1 << " a;";
-        if (i < num_reaction_wheels - 1)
+        this->output_file_path_string = csv_path + suffix + this->csv_ext;
+        std::ofstream output_file;
+        output_file.open(output_file_path_string);
+        if (output_file.is_open())
         {
-            std::cout << "\t\t";
+            output_file << "Time,Satelite theta x,Satelite theta y,Satelite theta z,Satellite Omega x,Satellite Omega y,Satellite Omega z,";
+            output_file << "Satellite alpha x,Satellite alpha y,Satellite alpha z,Accelerometer x,Accelerometer y,Accelerometer z,Gyro x,Gyro y,Gyro z,";
+            for (uint32_t i = 0; i < num_reaction_wheels; i++)
+            {
+                output_file << "Reaction wheel " << i << " Omega,Reaction wheel " << i << " alpha,";
+            }
+            output_file << std::endl;
+            output_file.close();
+        }
+        else
+        {
+            send_error("Unable to open file " + output_file_path_string);
         }
     }
-    std::cout << text_colour.reset << std::endl;
 
-    /* Write CSV header */
-    std::ofstream output_file;
-    output_file.open(output_file_path_string);
-
-    if (output_file.is_open())
-    {
-        output_file << "Time,Satelite theta x,Satelite theta y,Satelite theta z,Satellite Omega x,Satellite Omega y,Satellite Omega z,";
-        output_file << "Satellite alpha x,Satellite alpha y,Satellite alpha z,Accelerometer x,Accelerometer y,Accelerometer z,Gyro x,Gyro y,Gyro z,";
-        for (int i = 0; i < num_reaction_wheels; i++)
-        {
-            output_file << "Reaction wheel " << i << " Omega,Reaction wheel " << i << " alpha,";
-        }
-        output_file << std::endl;
-
-        // Close file?
-        output_file.close();
-    }
-    else
-    {
-        send_error("Unable to open file " + output_file_path_string);
-    }
+    return;
 }
+
 
 void Messenger::update_simulation_state(sim_config state, timestamp time)
 {
@@ -159,48 +172,52 @@ void Messenger::update_simulation_state(sim_config state, timestamp time)
 
 void Messenger::append_csv_output(sim_config state, timestamp time)
 {
-    // Open file (assuming it's still valid)
-    std::ofstream output_file;
-
-    try
+    /* don't bother trying to append if the file was never started. */
+    if ("-1" != this->output_file_path_string)
     {
-        output_file.open(output_file_path_string, std::fstream::out | std::fstream::app);
-    }
-    catch(const std::ios_base::failure& e)
-    {
-        send_error(e.what());
-    }
+        std::ofstream output_file;
 
-    if (output_file.is_open())
-    {
-        output_file << (float)time << ",";
-        output_file << state.satellite.theta_b.x() << "," << state.satellite.theta_b.y() << "," << state.satellite.theta_b.z() << ",";
-        output_file << state.satellite.omega_b.x() << "," << state.satellite.omega_b.y() << "," << state.satellite.omega_b.z() << ",";
-        output_file << state.satellite.alpha_b.x() << "," << state.satellite.alpha_b.y() << "," << state.satellite.alpha_b.z() << ",";
-
-        output_file << state.accelerometer.measurement.x() << "," << state.accelerometer.measurement.y() << "," << state.accelerometer.measurement.z() << ",";
-        output_file << state.gyroscope.measurement.x()     << "," << state.gyroscope.measurement.y()     << "," << state.gyroscope.measurement.z()     << ",";
-
-        for (uint32_t i = 0; i < state.reaction_wheels.size(); i++)
+        try
         {
-            float abs_omega = sqrt( state.reaction_wheels.at(i).omega.x()*state.reaction_wheels.at(i).omega.x() + 
-                                    state.reaction_wheels.at(i).omega.y()*state.reaction_wheels.at(i).omega.y() + 
-                                    state.reaction_wheels.at(i).omega.z()*state.reaction_wheels.at(i).omega.z() );
-            float abs_alpha = sqrt( state.reaction_wheels.at(i).alpha.x()*state.reaction_wheels.at(i).alpha.x() + 
-                                    state.reaction_wheels.at(i).alpha.y()*state.reaction_wheels.at(i).alpha.y() + 
-                                    state.reaction_wheels.at(i).alpha.z()*state.reaction_wheels.at(i).alpha.z() );
-
-            output_file << abs_omega << "," << abs_alpha << ",";
+            output_file.open(output_file_path_string, std::fstream::out | std::fstream::app);
         }
-        output_file << std::endl;
+        catch(const std::ios_base::failure& e)
+        {
+            send_error(e.what());
+        }
 
-        // Close file
-        output_file.close();
+        if (output_file.is_open())
+        {
+            output_file << (float)time << ",";
+            output_file << state.satellite.theta_b.x() << "," << state.satellite.theta_b.y() << "," << state.satellite.theta_b.z() << ",";
+            output_file << state.satellite.omega_b.x() << "," << state.satellite.omega_b.y() << "," << state.satellite.omega_b.z() << ",";
+            output_file << state.satellite.alpha_b.x() << "," << state.satellite.alpha_b.y() << "," << state.satellite.alpha_b.z() << ",";
+
+            output_file << state.accelerometer.measurement.x() << "," << state.accelerometer.measurement.y() << "," << state.accelerometer.measurement.z() << ",";
+            output_file << state.gyroscope.measurement.x()     << "," << state.gyroscope.measurement.y()     << "," << state.gyroscope.measurement.z()     << ",";
+
+            for (uint32_t i = 0; i < state.reaction_wheels.size(); i++)
+            {
+                float abs_omega = sqrt( state.reaction_wheels.at(i).omega.x()*state.reaction_wheels.at(i).omega.x() + 
+                                        state.reaction_wheels.at(i).omega.y()*state.reaction_wheels.at(i).omega.y() + 
+                                        state.reaction_wheels.at(i).omega.z()*state.reaction_wheels.at(i).omega.z() );
+                float abs_alpha = sqrt( state.reaction_wheels.at(i).alpha.x()*state.reaction_wheels.at(i).alpha.x() + 
+                                        state.reaction_wheels.at(i).alpha.y()*state.reaction_wheels.at(i).alpha.y() + 
+                                        state.reaction_wheels.at(i).alpha.z()*state.reaction_wheels.at(i).alpha.z() );
+
+                output_file << abs_omega << "," << abs_alpha << ",";
+            }
+            output_file << std::endl;
+
+            // Close file
+            output_file.close();
+        }
+        else
+        {
+            send_error("Unable to open file " + output_file_path_string);
+        }
     }
-    else
-    {
-        send_error("Unable to open file " + output_file_path_string);
-    }
+ 
     return;
 }
 

--- a/csdc-6/adcs-simulation/cpp/src/Simulator.cpp
+++ b/csdc-6/adcs-simulation/cpp/src/Simulator.cpp
@@ -37,6 +37,9 @@ void Simulator::init(sim_config initial_values)
 {
     /* TODO may need a check here**/
     this->system_vals = initial_values;
+
+    messenger->send_message("Starting simulation.");
+    messenger->start_new_sim(initial_values.reaction_wheels.size());
 }
 
 timestamp Simulator::update_simulation() {
@@ -72,7 +75,7 @@ void Simulator::simulate(timestamp t) {
         this->timestep();
     }
     
-    this->messenger->update_simulation_state(this->system_vals.satellite, this->simulation_time);
+    this->messenger->update_simulation_state(this->system_vals, this->simulation_time);
 }
 
 void Simulator::timestep() {

--- a/csdc-6/adcs-simulation/cpp/src/UI.cpp
+++ b/csdc-6/adcs-simulation/cpp/src/UI.cpp
@@ -13,7 +13,7 @@
 #include <string>
 #include <vector>
 #include <any>
-#include <iostream> 
+#include <iostream>
 
 #include "UI.hpp"
 #include "Simulator.hpp"
@@ -21,12 +21,19 @@
 #include "ConfigurationSingleton.hpp"
 #include "SensorActuatorFactory.hpp"
 
-
 UI::UI()
 {
-    allowed_commands["start_sim"] = std::bind(&UI::run_simulation, this, std::placeholders::_1);
-    allowed_commands["resume_sim"] = std::bind(&UI::resume_simulation, this, std::placeholders::_1);
-    allowed_commands["exit"] = std::bind(&UI::quit, this, std::placeholders::_1);
+    /* Full command names*/
+    allowed_commands["start_sim"]   = std::bind(&UI::run_simulation,    this, std::placeholders::_1);
+    allowed_commands["resume_sim"]  = std::bind(&UI::resume_simulation, this, std::placeholders::_1);
+    allowed_commands["exit"]        = std::bind(&UI::quit,              this, std::placeholders::_1);
+    allowed_commands["clean_out"]   = std::bind(&UI::clean_out,         this, std::placeholders::_1);
+
+    /* Aliases */
+    allowed_commands["ss"] = std::bind(&UI::run_simulation,    this, std::placeholders::_1);
+    allowed_commands["rs"] = std::bind(&UI::resume_simulation, this, std::placeholders::_1);
+    allowed_commands["q"]  = std::bind(&UI::quit,              this, std::placeholders::_1);
+    allowed_commands["co"] = std::bind(&UI::clean_out,         this, std::placeholders::_1);
 }
 
 void UI::start_ui_loop()
@@ -286,4 +293,15 @@ void UI::quit(std::vector<std::string> args)
 
     messenger.send_message("exiting.");
     exit(0);
+}
+
+void UI::clean_out(std::vector<std::string> args)
+{
+    if (num_exit_args != args.size())
+    {
+        throw invalid_ui_args("Invalid number of arguments.");
+    }
+
+    messenger.clean_csv_files();
+    return;
 }


### PR DESCRIPTION
CHANGES
- Added error functionality to messenger
- Added functions to support outputting the simulation data to csv
- Added calls to the messenger in Simulator::init to start the csv and print the header information
- Added a UI command to clean up all output csv files
- Added aliases to each UI command
- Fixed gitignore
- Added flag to cmake.sh to ignore unnecessary warnings

REASON
- CSV files will be used to chart results in Python

TESTING
Compiled code, ran simulation with current yaml. Behaves as before. New command works as expected.

GITHUB LINK
https://github.com/queens-satellite-team/adcs/issues/66

Signed-off-by: Aidan Sheedy <Aidan.P.Sheedy@gmail.com>