### PR TITLE
adcs-66 - fix errors in the mathematical model

### DIFF
--- a/csdc-6/adcs-simulation/cpp/simulator.yaml
+++ b/csdc-6/adcs-simulation/cpp/simulator.yaml
@@ -12,11 +12,11 @@
 #   Position: [3-dimensional vector]
 #   Velocity: [3-dimensional vector]
 Satellite:
-  Moment: [[0.16666666666,0,0],
-           [0,0.16666666666,0],
+  Moment: [[0.41666666666,0,0],
+           [0,0.41666666666,0],
            [0,0,0.16666666666]]
   Position: [0,0,0]
-  Velocity: [0,0,0]
+  Velocity: [2,1,3]
 
 # Actuators:
 #   Name: [name of actuator]
@@ -34,14 +34,14 @@ Satellite:
 Actuators:
   ReactionWheel1:
     type: ReactionWheel
-    Moment: 1
+    Moment: 2
     MaxAngVel: 1000
     MaxAngAccel: 1000
     MinAngVel: 0
     MinAngAccel: 0
     PollingTime: 10
     Position: [0,0,0]
-    Velocity: 1
+    Velocity: 2.5
     AxisOfRotation: [0,0,1]
     Acceleration: 1
 

--- a/csdc-6/adcs-simulation/cpp/src/UI.cpp
+++ b/csdc-6/adcs-simulation/cpp/src/UI.cpp
@@ -221,7 +221,7 @@ sim_config UI::get_sim_config(Configuration &config)
 {
     sim_config initial_values;
     Satellite temp;
-    initial_values.satellite.alpha_b = Eigen::Vector3f::Zero();
+    initial_values.satellite.alpha_b   = Eigen::Vector3f::Zero();
     initial_values.satellite.omega_b   = config.GetSatelliteVelocity();
     initial_values.satellite.theta_b   = config.GetSatellitePosition();
     initial_values.satellite.inertia_b = config.GetSatelliteMoment();


### PR DESCRIPTION
CHANGES
- acceleration is now incremented using jerk. NOTE: jerk is currently set to zero. We need the true value from the reaction wheel datasheet 
- the satellite's acceleration is now calculated as a sum of each reaction wheel 
- the calculation for the satellite's acceleration has been updated to reflect the equation used in the unit tests 
- the reaction wheel's moment and omega are now represented in vector form by multiplying by the axis of rotation

REASON
The simulation was failing unit tests 5 and 6. All unit tests now pass

TESTING
Output now matches the six unit tests

GITHUB LINK
#66

Signed-off-by: Lily de Loe