### PR TITLE
adcs-66 - have gyros return current pos, accel, and vel.

### DIFF
--- a/csdc-6/adcs-control-code/inc/PointingModeController.hpp
+++ b/csdc-6/adcs-control-code/inc/PointingModeController.hpp
@@ -6,7 +6,7 @@
  * @authors Justin Paoli, Aidan Sheedy
  *
  * Last Edited
- * 2022-11-07
+ * 2022-11-13
 **/
 
 #pragma once
@@ -38,7 +38,7 @@ public:
     * @details Starts the command loop. Should call the update functions once per cycle to get
     * updated sensor measurements and sent commands to actuators accordingly
    **/
-    void begin(std::vector<float> desired_attitude);
+    void begin(Eigen::Vector3f desired_attitude);
 
 private:
     /**
@@ -55,16 +55,27 @@ private:
    **/
     std::unordered_map<std::string, std::shared_ptr<Actuator>> actuators;
 
+    Eigen::Vector3f prev_error;
+
+    Eigen::Vector3f prev_integral;
+
     ADCS_timer *timer;
 
     /**
     * @name take_updated_measurements
+    * @returns [measurement]
     *
-    * @details Iterates through all of the sensors, taking updated measurements from
-    * any that are ready.
-    *
-    * TODO: should possibly not be void? Depends on if we want to store the sensor
-    * measurements as class properties or have this function return them.
+    * @details For now just checks the gyroscope to get an updated current attitude
+    * of the satellite.
    **/
-    void take_updated_measurements();
+    measurement take_updated_measurements();
+
+    /**
+    * @name update
+    *
+    * @details One cycle of the PID controller iteration. Recalculates the desired torque
+    * based on the current attitude of the satellite and updates the accelerations of the 
+    * reaction wheels.
+   **/
+    void update(Eigen::Vector3f current_attitude, Eigen::Vector3f desired_attitude, timestamp delta_t);
 };

--- a/csdc-6/adcs-control-code/interface/inc/def_interface.hpp
+++ b/csdc-6/adcs-control-code/interface/inc/def_interface.hpp
@@ -304,6 +304,14 @@ typedef struct
     timestamp       time_taken;
 } measurement;
 
+typedef struct
+{
+    Eigen::Vector3f position;
+    Eigen::Vector3f velocity;
+    Eigen::Vector3f acceleration;
+    timestamp       time_taken;
+} gyro_state;
+
 /**
  * @struct  actuator_state
  * 

--- a/csdc-6/adcs-control-code/src/PointingModeController.cpp
+++ b/csdc-6/adcs-control-code/src/PointingModeController.cpp
@@ -6,11 +6,9 @@
  * @authors Justin Paoli
  *
  * Last Edited
- * 2022-11-06
+ * 2022-11-13
 **/
 
-#include <chrono>
-#include <thread>
 #include "PointingModeController.hpp"
 
 PointingModeController::PointingModeController(
@@ -23,20 +21,71 @@ PointingModeController::PointingModeController(
     this->timer = timer;
 }
 
-void PointingModeController::begin(std::vector<float> desired_attitude) {
-    (void) desired_attitude;    /*  Silences "unsued parameter" compiler warning. This function will be
-                                    updated later anyway so for now this is fine. */
+void PointingModeController::begin(Eigen::Vector3f desired_attitude) {
     //TODO: convert to while and add exit condition
-    for (int i = 0; i < 1; i++) {
-        this->timer->get_time();
-        // this->take_updated_measurements();
-        //std::chrono::seconds duration(1);
-        //std::this_thread::sleep_for(duration);
+    measurement initial_vals = this->take_updated_measurements();
+    timestamp prev_time = initial_vals.time_taken;
+    prev_error = desired_attitude - initial_vals.vec;
+    prev_integral = Eigen::Vector3f::Zero();
+    for (int i = 0; i < 5000; i++) {
+        measurement m = this->take_updated_measurements();
+        timestamp delta_t = m.time_taken - prev_time;
+        prev_time = m.time_taken;
+        this->update(m.vec, desired_attitude, delta_t);
     }
 }
 
-void PointingModeController::take_updated_measurements() {
-    // for (const auto &s : sensors) {
-    //     s.second->take_measurement();
-    // }
+void PointingModeController::update(Eigen::Vector3f current_attitude, Eigen::Vector3f desired_attitude, timestamp delta_t) {
+    Eigen::Vector3f kp(0.0002, 0.0002, 0.0002);
+    Eigen::Vector3f kd(0.005544, 0.005775, 0.0052472);
+    Eigen::Vector3f ki(0.00001, 0.0000096, 0.00001057);
+
+    Eigen::Vector3f cur_error = desired_attitude - current_attitude;
+    Eigen::Vector3f cur_derivative = (cur_error - prev_error) / (float) delta_t;
+    Eigen::Vector3f cur_integral = prev_integral + cur_error * (float) delta_t;
+
+    prev_error = cur_error;
+    prev_integral = cur_integral;
+
+    Eigen::Vector3f desired_torque = -1 * (kp.cwiseProduct(cur_error) + kd.cwiseProduct(cur_derivative) + ki.cwiseProduct(cur_integral));
+
+    int num_rws = actuators.size();
+    int i = 0;
+    Eigen::Matrix3Xf A;
+    A.resize(3, num_rws);
+    for (const auto &a : actuators) {
+        if (Reaction_wheel* rw = dynamic_cast<Reaction_wheel*>(a.second.get())) {
+            A.col(i++) << rw->get_axis_of_rotation();
+        }
+    }
+
+    Eigen::VectorXf rw_torques = A.transpose() * (A * A.transpose()).inverse() * desired_torque;
+    // std::cout << "Timestep:" << std::endl << (float) delta_t << std::endl;
+    // std::cout << "Error:" << std::endl << cur_error << std::endl;
+    // std::cout << "Derivative:" << std::endl << cur_derivative << std::endl;
+    // std::cout << "Integral:" << std::endl << cur_integral << std::endl;
+    // std::cout << "Torques:" << std::endl << desired_torque << std::endl;
+
+    i = 0;
+    for (const auto &a : actuators) {
+        if (Reaction_wheel* rw = dynamic_cast<Reaction_wheel*>(a.second.get())) {
+            rw->set_target_state({ 
+                rw_torques.coeff(i, 0) / rw->get_inertia_matrix(), 
+                rw->get_current_state().velocity, 
+                rw->get_current_state().position,
+                this->timer->get_time() 
+            });
+            i++;
+        }
+    }
+}
+
+measurement PointingModeController::take_updated_measurements() {
+    for (const auto &s : sensors) {
+        if (Gyroscope* gyro = dynamic_cast<Gyroscope*>(s.second.get())) {
+            gyro_state state = gyro->take_measurement();
+            return { state.position, state.time_taken };
+        }
+    }
+    return { Eigen::Vector3f::Zero(), 0 };
 }

--- a/csdc-6/adcs-control-code/src/PointingModeController.cpp
+++ b/csdc-6/adcs-control-code/src/PointingModeController.cpp
@@ -28,14 +28,15 @@ void PointingModeController::begin(std::vector<float> desired_attitude) {
                                     updated later anyway so for now this is fine. */
     //TODO: convert to while and add exit condition
     for (int i = 0; i < 1; i++) {
-        this->take_updated_measurements();
+        this->timer->get_time();
+        // this->take_updated_measurements();
         //std::chrono::seconds duration(1);
         //std::this_thread::sleep_for(duration);
     }
 }
 
 void PointingModeController::take_updated_measurements() {
-    for (const auto &s : sensors) {
-        s.second->take_measurement();
-    }
+    // for (const auto &s : sensors) {
+    //     s.second->take_measurement();
+    // }
 }

--- a/csdc-6/adcs-simulation/cpp/inc/CommonStructs.hpp
+++ b/csdc-6/adcs-simulation/cpp/inc/CommonStructs.hpp
@@ -94,7 +94,9 @@ typedef struct
 **/
 typedef struct
 {
-    Eigen::Vector3f measurement;
+    Eigen::Vector3f theta;
+    Eigen::Vector3f omega;
+    Eigen::Vector3f alpha;
     Eigen::Vector3f position;
 } sim_gyroscope;
 

--- a/csdc-6/adcs-simulation/cpp/inc/Simulator.hpp
+++ b/csdc-6/adcs-simulation/cpp/inc/Simulator.hpp
@@ -106,7 +106,7 @@ public:
      * 
      * @returns the current time at the moment the measurement was taken.
     **/
-    timestamp gyroscope_take_measurement(Eigen::Vector3f *measurement);
+    gyro_state gyroscope_take_measurement();
 
     /**
      * @name accelerometer_take_measurement

--- a/csdc-6/adcs-simulation/cpp/interface/inc/sim_interface.hpp
+++ b/csdc-6/adcs-simulation/cpp/interface/inc/sim_interface.hpp
@@ -118,6 +118,8 @@ class Sensor : public ADCS_device {
         virtual ~Sensor(){}
 
         /**
+         * @note commenting out for now but this may need to be removed entirely. Keeping until a decision is made.
+         * 
          * @name    take_measurement
          *
          * @details this function takes a measurement using the sensor. The simulation is also told
@@ -125,11 +127,11 @@ class Sensor : public ADCS_device {
          *
          * @returns the required measurement if succesful.
         **/
-        virtual measurement take_measurement() // MAY need to create a default implementation
-        {
-            measurement empty;
-            return empty;
-        } 
+        // virtual measurement take_measurement() // MAY need to create a default implementation
+        // {
+        //     measurement empty;
+        //     return empty;
+        // } 
 
         /**
          * @name    set_current_vals
@@ -387,7 +389,7 @@ class Gyroscope : public Sensor {
          *
          * @returns the required measurement if succesful.
         **/
-        measurement take_measurement();
+        gyro_state take_measurement();
 };
 
 /**

--- a/csdc-6/adcs-simulation/cpp/interface/inc/sim_interface.hpp
+++ b/csdc-6/adcs-simulation/cpp/interface/inc/sim_interface.hpp
@@ -245,6 +245,15 @@ class Actuator : public ADCS_device
         **/
         Eigen::Vector3f get_position();
 
+        /**
+         * @name    get_axis_of_rotation
+         *
+         * @details accessor for the axis of rotation of the actuator.
+         *
+         * @returns the axis of rotation of the actuator.
+        **/
+        Eigen::Vector3f get_axis_of_rotation();
+
     protected:
         /**
          * @name    set_current_state

--- a/csdc-6/adcs-simulation/cpp/interface/src/Actuator.cpp
+++ b/csdc-6/adcs-simulation/cpp/interface/src/Actuator.cpp
@@ -50,6 +50,10 @@ Eigen::Vector3f Actuator::get_position()
     return this->position;
 }
 
+Eigen::Vector3f Actuator::get_axis_of_rotation()
+{
+    return this->axis_of_rotation;
+}
 
 void Actuator::check_valid_state(actuator_state state)
 {

--- a/csdc-6/adcs-simulation/cpp/interface/src/Gyroscope.cpp
+++ b/csdc-6/adcs-simulation/cpp/interface/src/Gyroscope.cpp
@@ -14,21 +14,19 @@
 
 #include "sim_interface.hpp"
 
-measurement Gyroscope::take_measurement()
+gyro_state Gyroscope::take_measurement()
 {
     if (this->time_until_ready() > 0)
     {
         /* THROW APPROPRIATE EXCEPTION**/
     }
 
-    Eigen::Vector3f measurement;
-    measurement = Eigen::Vector3f::Zero();
+    gyro_state measurement = this->sim->gyroscope_take_measurement();
+    this->update_poll_time(measurement.time_taken);
 
-    timestamp current_time = this->sim->gyroscope_take_measurement(&measurement);
-    this->update_poll_time(current_time);
+    /* commenting out for now, but may not need either of these lines. Leaving as comments until confirmed. */
+    // this->current_vector_value.time_taken = current_time;
+    // this->current_vector_value.vec = measurement;
 
-    this->current_vector_value.time_taken = current_time;
-    this->current_vector_value.vec = measurement;
-
-    return this->current_vector_value;
+    return measurement;
 }

--- a/csdc-6/adcs-simulation/cpp/interface/src/Reaction_wheel.cpp
+++ b/csdc-6/adcs-simulation/cpp/interface/src/Reaction_wheel.cpp
@@ -62,3 +62,4 @@ actuator_state Reaction_wheel::get_current_state()
     this->sim->reaction_wheel_get_current_state(this->position);
     return this->current_state;
 }
+

--- a/csdc-6/adcs-simulation/cpp/simulator_1.yaml
+++ b/csdc-6/adcs-simulation/cpp/simulator_1.yaml
@@ -15,8 +15,8 @@ Satellite:
   Moment: [[0.02035470141,0.00004983389,0.00021768132],
            [0.00004983389,0.01993812272,-0.00007588037],
            [0.00021768132,-0.00007588037,0.0053506098]]
-  Position: [1,1,1]
-  Velocity: [10,10,10]
+  Position: [0, 0, 0]
+  Velocity: [0, 0, 0]
 
 # Actuators:
 #   Name: [name of actuator]
@@ -39,8 +39,9 @@ Actuators:
     MinAngAccel: 0
     PollingTime: 10
     Position: [1.73205080757,1.73205080757,-1.73205080757]
-    AxisOfRotation: []
-    Velocity: [1,1,1]
+    AxisOfRotation: [0.577350269, 0.577350269, -0.577350269]
+    Velocity: 0
+    Acceleration: 0
   ReactionWheel2:
     type: ReactionWheel
     Moment: 0.00000925
@@ -50,7 +51,9 @@ Actuators:
     MinAngAccel: 0
     PollingTime: 10
     Position: [1.73205080757,-1.73205080757,-1.73205080757]
-    Velocity: [1,1,1]
+    AxisOfRotation: [0.577350269, -0.577350269, -0.577350269]
+    Velocity: 0
+    Acceleration: 0
   ReactionWheel3:
     type: ReactionWheel
     Moment: 0.00000925
@@ -60,7 +63,9 @@ Actuators:
     MinAngAccel: 0
     PollingTime: 10
     Position: [-1.73205080757,-1.73205080757,-1.73205080757]
-    Velocity: [1,1,1]
+    AxisOfRotation: [-0.577350269, -0.577350269, -0.577350269]
+    Velocity: 0
+    Acceleration: 0
   ReactionWheel4:
     type: ReactionWheel
     Moment: 0.00000925
@@ -70,7 +75,9 @@ Actuators:
     MinAngAccel: 0
     PollingTime: 10
     Position: [-1.73205080757,1.73205080757,-1.73205080757]
-    Velocity: [1,1,1]
+    AxisOfRotation: [-0.577350269, 0.577350269, -0.577350269]
+    Velocity: 0
+    Acceleration: 0
 
 # Sensors:
 #   Name: [name of sensor]

--- a/csdc-6/adcs-simulation/cpp/src/Messenger.cpp
+++ b/csdc-6/adcs-simulation/cpp/src/Messenger.cpp
@@ -139,25 +139,25 @@ void Messenger::update_simulation_state(sim_config state, timestamp time)
 {
     // Do we need any checks on state?
 
-    // for now just text dump - next step is graphs for each.
-    std::cout << text_colour.reset << time.pretty_string() << "\t" << std::setprecision(4) << std::fixed;
-    std::cout << state.satellite.theta_b.x() << ", " << state.satellite.theta_b.y() << ", " << state.satellite.theta_b.z() << ";\t";
-    std::cout << state.satellite.omega_b.x() << ", " << state.satellite.omega_b.y() << ", " << state.satellite.omega_b.z() << ";\t";
-    std::cout << state.satellite.alpha_b.x() << ", " << state.satellite.alpha_b.y() << ", " << state.satellite.alpha_b.z() << ";\t";
+    // // for now just text dump - next step is graphs for each.
+    // std::cout << text_colour.reset << time.pretty_string() << "\t" << std::setprecision(4) << std::fixed;
+    // std::cout << state.satellite.theta_b.x() << ", " << state.satellite.theta_b.y() << ", " << state.satellite.theta_b.z() << ";\t";
+    // std::cout << state.satellite.omega_b.x() << ", " << state.satellite.omega_b.y() << ", " << state.satellite.omega_b.z() << ";\t";
+    // std::cout << state.satellite.alpha_b.x() << ", " << state.satellite.alpha_b.y() << ", " << state.satellite.alpha_b.z() << ";\t";
 
-    std::cout << state.accelerometer.measurement.x() << ", " << state.accelerometer.measurement.y() << ", " << state.accelerometer.measurement.z() << ";\t";
-    // std::cout << state.gyroscope.measurement.x()     << ", " << state.gyroscope.measurement.y()     << ", " << state.gyroscope.measurement.z() << ";";
+    // std::cout << state.accelerometer.measurement.x() << ", " << state.accelerometer.measurement.y() << ", " << state.accelerometer.measurement.z() << ";\t";
+    // // std::cout << state.gyroscope.measurement.x()     << ", " << state.gyroscope.measurement.y()     << ", " << state.gyroscope.measurement.z() << ";";
 
-    for (uint32_t i = 0; i < state.reaction_wheels.size(); i++)
-    {   
-        std::cout << "\t" << state.reaction_wheels.at(i).omega << ", " << state.reaction_wheels.at(i).alpha << ";";
+    // for (uint32_t i = 0; i < state.reaction_wheels.size(); i++)
+    // {   
+    //     std::cout << "\t" << state.reaction_wheels.at(i).omega << ", " << state.reaction_wheels.at(i).alpha << ";";
 
-        if (i < state.reaction_wheels.size() - 1)
-        {
-            std::cout << "\t";
-        }
-    }
-    std::cout << std::endl;
+    //     if (i < state.reaction_wheels.size() - 1)
+    //     {
+    //         std::cout << "\t";
+    //     }
+    // }
+    // std::cout << std::endl;
 
     this->append_csv_output(state, time);
 

--- a/csdc-6/adcs-simulation/cpp/src/Messenger.cpp
+++ b/csdc-6/adcs-simulation/cpp/src/Messenger.cpp
@@ -70,7 +70,7 @@ void Messenger::write_cout_header(uint32_t num_reaction_wheels)
 {
     std::cout << text_colour.magenta << "Time" << "\t\t";
     std::cout << "Sat tx, Sat ty, Sat tz;\t\t" << "Sat wx, Sat wy, Sat wz;\t\t" << "Sat ax, Sat ay, Sat az;\t\t";
-    std::cout << "Accel x, Accel y, Accel z;\t" << "Gyro x, Gyro y, Gyro z;\t\t";
+    std::cout << "Accel x, Accel y, Accel z;\t";// << "Gyro x, Gyro y, Gyro z;\t\t";
     for (uint32_t i = 0; i < num_reaction_wheels; i++)
     {
         std::cout << "RW " << i+1 << " O, RW " << i+1 << " a;";
@@ -117,7 +117,7 @@ void Messenger::write_csv_header(uint32_t num_reaction_wheels)
         if (output_file.is_open())
         {
             output_file << "Time,Satellite theta x,Satellite theta y,Satellite theta z,Satellite Omega x,Satellite Omega y,Satellite Omega z,";
-            output_file << "Satellite alpha x,Satellite alpha y,Satellite alpha z,Accelerometer x,Accelerometer y,Accelerometer z,Gyro x,Gyro y,Gyro z,";
+            output_file << "Satellite alpha x,Satellite alpha y,Satellite alpha z,Accelerometer x,Accelerometer y,Accelerometer z,";//Gyro x,Gyro y,Gyro z,";
             for (uint32_t i = 0; i < num_reaction_wheels; i++)
             {
                 output_file << "Reaction wheel " << i << " Omega,Reaction wheel " << i << " alpha,";
@@ -141,12 +141,12 @@ void Messenger::update_simulation_state(sim_config state, timestamp time)
 
     // for now just text dump - next step is graphs for each.
     std::cout << text_colour.reset << time.pretty_string() << "\t" << std::setprecision(4) << std::fixed;
-    std::cout << state.satellite.theta_b.x() << ", " << state.satellite.theta_b.y() << ", " << state.satellite.theta_b.z() << ";\t\t";
+    std::cout << state.satellite.theta_b.x() << ", " << state.satellite.theta_b.y() << ", " << state.satellite.theta_b.z() << ";\t";
     std::cout << state.satellite.omega_b.x() << ", " << state.satellite.omega_b.y() << ", " << state.satellite.omega_b.z() << ";\t";
     std::cout << state.satellite.alpha_b.x() << ", " << state.satellite.alpha_b.y() << ", " << state.satellite.alpha_b.z() << ";\t";
 
     std::cout << state.accelerometer.measurement.x() << ", " << state.accelerometer.measurement.y() << ", " << state.accelerometer.measurement.z() << ";\t";
-    std::cout << state.gyroscope.measurement.x()     << ", " << state.gyroscope.measurement.y()     << ", " << state.gyroscope.measurement.z() << ";";
+    // std::cout << state.gyroscope.measurement.x()     << ", " << state.gyroscope.measurement.y()     << ", " << state.gyroscope.measurement.z() << ";";
 
     for (uint32_t i = 0; i < state.reaction_wheels.size(); i++)
     {   
@@ -188,7 +188,7 @@ void Messenger::append_csv_output(sim_config state, timestamp time)
             output_file << state.satellite.alpha_b.x() << "," << state.satellite.alpha_b.y() << "," << state.satellite.alpha_b.z() << ",";
 
             output_file << state.accelerometer.measurement.x() << "," << state.accelerometer.measurement.y() << "," << state.accelerometer.measurement.z() << ",";
-            output_file << state.gyroscope.measurement.x()     << "," << state.gyroscope.measurement.y()     << "," << state.gyroscope.measurement.z()     << ",";
+            // output_file << state.gyroscope.measurement.x()     << "," << state.gyroscope.measurement.y()     << "," << state.gyroscope.measurement.z()     << ",";
 
             for (uint32_t i = 0; i < state.reaction_wheels.size(); i++)
             {

--- a/csdc-6/adcs-simulation/cpp/src/Simulator.cpp
+++ b/csdc-6/adcs-simulation/cpp/src/Simulator.cpp
@@ -105,7 +105,10 @@ void Simulator::timestep() {
 
     // Update new internal sensor and actuator values
     system_vals.accelerometer.measurement = system_vals.satellite.alpha_b.cross(system_vals.accelerometer.position);
-    system_vals.gyroscope.measurement = system_vals.satellite.alpha_b;
+    
+    system_vals.gyroscope.alpha = system_vals.satellite.alpha_b;
+    system_vals.gyroscope.omega = system_vals.satellite.omega_b;
+    system_vals.gyroscope.theta = system_vals.satellite.theta_b;
 
     // This no longer works
     // Print current values to UI
@@ -146,12 +149,17 @@ actuator_state Simulator::reaction_wheel_get_current_state(Eigen::Vector3f posit
     return ret;
 }
 
-timestamp Simulator::gyroscope_take_measurement(Eigen::Vector3f *measurement)
+gyro_state Simulator::gyroscope_take_measurement()
 {
     this->update_simulation();
-    *measurement = this->system_vals.gyroscope.measurement;
+    gyro_state ret;
 
-    return this->simulation_time;
+    ret.acceleration = this->system_vals.gyroscope.alpha;
+    ret.velocity     = this->system_vals.gyroscope.omega;
+    ret.position     = this->system_vals.gyroscope.theta;
+    ret.time_taken   = this->simulation_time;
+
+    return ret;
 }
 
 timestamp Simulator::accelerometer_take_measurement(Eigen::Vector3f *measurement)

--- a/csdc-6/adcs-simulation/cpp/src/Simulator.cpp
+++ b/csdc-6/adcs-simulation/cpp/src/Simulator.cpp
@@ -43,15 +43,17 @@ void Simulator::init(sim_config initial_values)
 }
 
 timestamp Simulator::update_simulation() {
-    timestamp time_passed = this->determine_time_passed();
-    this->simulate(time_passed);
+    //timestamp time_passed = this->determine_time_passed();
+    timestamp t(10, 0);
+    this->simulate(t);
 
     return this->simulation_time;
 }
 
 timestamp Simulator::set_adcs_sleep(timestamp duration) {
-    timestamp time_passed = this->determine_time_passed();
-    this->simulate(time_passed + duration);
+    //timestamp time_passed = this->determine_time_passed();
+    timestamp t(10, 0);
+    this->simulate(t + duration);
 
     return this->simulation_time;
 }
@@ -119,7 +121,7 @@ timestamp Simulator::reaction_wheel_update_desired_state(Eigen::Vector3f wheel_p
 {
     // figure out what reaction wheel it is from the position vector
 
-    for (sim_reaction_wheel wheel : system_vals.reaction_wheels) {
+    for (sim_reaction_wheel &wheel : system_vals.reaction_wheels) {
         if (wheel.position.isApprox(wheel_position)) {
             // Update the target state (For now just change the acceleration to match,
             // when it reaches it's target position just change accel to 0)
@@ -127,7 +129,7 @@ timestamp Simulator::reaction_wheel_update_desired_state(Eigen::Vector3f wheel_p
         }
     }
 
-    this->update_simulation();
+    //this->update_simulation();
     return this->simulation_time;
 }
 

--- a/csdc-6/adcs-simulation/cpp/src/UI.cpp
+++ b/csdc-6/adcs-simulation/cpp/src/UI.cpp
@@ -167,7 +167,7 @@ void UI::run_simulation(std::vector<std::string> args)
     ADCS_timer timer(&simulator);
     PointingModeController controller(sensors, actuators, &timer);
 
-    controller.begin({0}); // Empty desired attitude for now
+    controller.begin({ 0.5, 0.5, 0.5});
 
     /* This code should not be deleted - it will be necessary when the final_state_yaml is implemented.**/
     // string final_state_yaml_path;

--- a/csdc-6/adcs-simulation/cpp/src/UI.cpp
+++ b/csdc-6/adcs-simulation/cpp/src/UI.cpp
@@ -237,7 +237,9 @@ sim_config UI::get_sim_config(Configuration &config)
                 break;
             case SensorType::Gyroscope:
                 initial_values.gyroscope.position = sensor_config->position;
-                initial_values.gyroscope.measurement = Eigen::Vector3f::Zero();
+                initial_values.gyroscope.alpha = Eigen::Vector3f::Zero();
+                initial_values.gyroscope.omega = Eigen::Vector3f::Zero();
+                initial_values.gyroscope.theta = Eigen::Vector3f::Zero();
                 break;
         }
     }


### PR DESCRIPTION
CHANGES
- added "gyro_state" struct to default interface
- temp update to controller to use the timer to increment the sim
- added all angular params to "sim_gyroscope" common structure
- updated simulator to use new "gyro_state" struct
- change gyro take_measurement function to use the gyro_state struct
- Removed gyro from all messenger functions (for now)

REASON
Need position for the pointing mode controller. We can update the Gyro to be more accurate to the actual sensor later, for the controller all it cares about is the final result.

TESTING
Compiles and can run unit tests.

GITHUB LINK
https://github.com/queens-satellite-team/adcs/issues/66

Signed-off-by: Aidan-Sheedy <Aidan.P.Sheedy@gmail.com>