### PR TITLE
adcs-66 implement second yaml for controller parameters

### DIFF
--- a/csdc-6/adcs-control-code/interface/inc/def_interface.hpp
+++ b/csdc-6/adcs-control-code/interface/inc/def_interface.hpp
@@ -57,7 +57,7 @@ class timestamp_nullptr : public std::exception
         const char* message;
 };
 
-/* ADCS specific timestamp definition. All time measurements use this structure.
+/** ADCS specific timestamp definition. All time measurements use this structure.
  *
  * @param milliseconds  number of milliseconds of the timestamp
  * @param seconds       number of seconds of the timestamp. This is rolled-over from milliseconds.

--- a/csdc-6/adcs-simulation/cpp/CMakeLists.txt
+++ b/csdc-6/adcs-simulation/cpp/CMakeLists.txt
@@ -18,6 +18,7 @@ add_executable(simulator
     src/ConfigurationSingleton.cpp
     src/UI.cpp
     src/Messenger.cpp
+    src/DummyController.cpp
     interface/src/Actuator.cpp
     interface/src/ADCS_device.cpp
     interface/src/ADCS_timer.cpp

--- a/csdc-6/adcs-simulation/cpp/inc/ConfigurationSingleton.hpp
+++ b/csdc-6/adcs-simulation/cpp/inc/ConfigurationSingleton.hpp
@@ -3,10 +3,10 @@
  *
  * @details hpp file for singleton class used to configure the user's sensor/actuator inputs
  *
- * @authors Lily de Loe
+ * @authors Lily de Loe, Aidan Sheedy
  *
  * Last Edited
- * 2022-11-08
+ * 2022-11-15
  *
 **/
 
@@ -123,6 +123,15 @@ public:
     bool Load(const std::string &fileName);
 
     /**
+    * @name load_exit_file
+    * 
+    * @param fileName [string], the input YAML file's name
+    * 
+    * @details loads the exit YAML file
+   **/
+    bool load_exit_file(const std::string &fileName);
+
+    /**
     * @details copy constructor is explicitly deleted to prevent C++ from auto-generating one
    **/
     Configuration(const Configuration &) = delete;
@@ -217,14 +226,65 @@ public:
 
     /**
     * @name GetTimestepInMilliSeconds
-    * @return the timestep, in seconds, as a float
+    * @return the timestep, in seconds, as an int
     * 
     * @details getter for the update timestep 
     */
-    inline const float &GetTimestepInMilliSeconds(){
+    inline const int &GetTimestepInMilliSeconds(){
         return timestepInMilliSeconds;
     }
 
+    /**
+    * @name    getTimeout
+    * 
+    * @returns the timeout, in seconds, as a float
+    * 
+    * @details getter for the timeout
+    */
+    inline const int &getTimeout()
+    {
+        return timeoutInMilliseconds;
+    }
+
+    /**
+    * @name    getDesiredSatellitePosition
+    * 
+    * @returns the desired satellite position for the controller
+    */
+    inline const Eigen::Vector3f &getDesiredSatellitePosition()
+    {
+        return desiredSatellitePosition;
+    }
+
+    /**
+    * @name    getAllowedJitter
+    * 
+    * @returns the allowed jitter for the controller, in degrees/second
+    */
+    inline const float &getAllowedJitter()
+    {
+        return allowed_jitter;
+    }
+
+    /**
+    * @name    getRequiredAccuracy
+    * 
+    * @returns the required accuracy of the controller, in degrees
+    */
+    inline const float &getRequiredAccuracy()
+    {
+        return required_accuracy;
+    }
+
+    /**
+    * @name    getHoldTime
+    * 
+    * @returns the amount of time the controller needs to hold the target, in ms
+    */
+    inline const int &getHoldTime()
+    {
+        return required_hold_time;
+    }
 
 private:
     /**
@@ -268,6 +328,23 @@ private:
     /**
      * @details float storing the timestep in milliseconds
     */
-    float timestepInMilliSeconds;
+    int timestepInMilliSeconds;
+
+    /**
+     * @details float storing the timeout in milliseconds
+    */
+    int timeoutInMilliseconds;
+
+    /* the desired satellite position for the controller */
+    Eigen::Vector3f desiredSatellitePosition;
+
+    /* the allowed jitter for the controller, in degrees/second */
+    float allowed_jitter;
+
+    /* the required accuracy of the controller, in degrees */
+    float required_accuracy;
+
+    /* the amount of time the controller needs to hold the target, in ms */
+    int required_hold_time;
 
 };

--- a/csdc-6/adcs-simulation/cpp/inc/DummyController.hpp
+++ b/csdc-6/adcs-simulation/cpp/inc/DummyController.hpp
@@ -1,0 +1,54 @@
+/**
+ * @file    DummyController.hpp
+ *
+ * @details Header file for the dummy controller
+ *
+ * @authors Aidan Sheedy
+ *
+ * Last Edited
+ * 2022-11-14
+**/
+
+#pragma once
+
+#include <unordered_map>
+
+#include "interface.hpp"
+
+/**
+ * Runs the simulation on an infinite loop -> or at least until the default maximum timeout of 1h.
+ * 
+ * @param timer [ADCS_timer*] timer used to update the simulation.
+**/
+class DummyController {
+public:
+    /**
+     * @details Constructor for the DummyController class. Saves the timer pointer.
+     *
+     * @param timer timer used to update the simulation.
+     *
+    **/
+    DummyController(ADCS_timer *timer);
+
+    /**
+     * @details delete default constructor for the DummyController class to avoid seg faults
+    **/
+    DummyController() = delete;
+
+    /**
+     * @name begin
+     *
+     * @details Starts the command loop. Should calls the timer once per loop to update time sim.
+     *
+     * @param desired_attitue [vector<float>], the desired angle to point at
+     *
+    **/
+    void begin();
+
+private:
+    /* Timer used to update the simulation. */
+    ADCS_timer *timer;
+
+    /* Hard timeout limit is set to 1 hour of simulation. */
+    timestamp timeout = timestamp(0x36EE80, 0);
+};

--- a/csdc-6/adcs-simulation/cpp/inc/Messenger.hpp
+++ b/csdc-6/adcs-simulation/cpp/inc/Messenger.hpp
@@ -121,6 +121,38 @@ class Messenger
         **/
         void clean_csv_files();
 
+        /**
+         * @name    silence_sim_prints
+         *
+         * @details silences all terminal prints during the simulation run
+        **/
+        void silence_sim_prints();
+
+        /**
+         * @name    reset_defaults
+         *
+         * @details resets all settings to default values
+        **/
+        void reset_defaults();
+
+        /**
+         * @name    set_csv_print_rate
+         *
+         * @details sets the print rate to the csv file in terms of simulation time.
+         * 
+         * @param   csv_rate [uint32_t] the timestep in ms that the csv will be updated
+        **/
+        void set_csv_print_rate(uint32_t csv_rate);
+
+        /**
+         * @name    set_terminal_print_rate
+         *
+         * @details sets the print rate to the terminal in terms of simulation time.
+         *
+         * @param   csv_rate [uint32_t] the timestep in ms that the terminal will be updated
+        **/
+        void set_terminal_print_rate(uint32_t terminal_rate);
+
     private:
         /**
          * @name    append_csv_output
@@ -146,8 +178,38 @@ class Messenger
         /* extension of csv files */
         const std::string csv_ext = ".csv";
 
+        /* default state of the terminal prints */
+        const bool default_silent_sim_prints = false;
+
+        /* default print rate to the csv file in ms */
+        const uint32_t default_csv_print_rate = 1;
+
+        /* default print rate to the terminal in ms */
+        const uint32_t default_terminal_print_rate = 10;
+
         /* full string of the output path */
         std::string output_file_path_string = "";
+
+        /* state of the terminal prints */
+        bool silent_sim_prints = false;
+
+        /* print rate to the csv file in ms */
+        uint32_t csv_print_rate = 1;
+
+        /* print rate to the terminal in ms */
+        uint32_t terminal_print_rate = 10;
+
+        /**
+         * number of attempts to write to csv. Each count corresponds to 1 ms, and gets reset when
+         * it reaches csv_print_rate
+        **/
+        uint32_t csv_write_count = 0;
+
+        /**
+         * number of attempts to write to the terminal. Each count corresponds to 1 ms, and gets
+         * reset when it reaches csv_print_rate
+        **/
+        uint32_t terminal_write_count = 0;
 
 };
 

--- a/csdc-6/adcs-simulation/cpp/inc/Simulator.hpp
+++ b/csdc-6/adcs-simulation/cpp/inc/Simulator.hpp
@@ -42,7 +42,7 @@ public:
     *
     * @details Initializes the simulation with starting values.
    **/
-    void init(sim_config initial_values);
+    void init(sim_config initial_values, timestamp timeout);
 
     /**
     * @name update_simulation
@@ -186,4 +186,29 @@ private:
      * @details pointer to a messenger object to rely messages and status updates to the user.
     **/  
     Messenger *messenger;
+
+    /**
+     * @property timeout [timestamp]
+     * 
+     * @details  maximum amount of time the simulator is allowed to run.
+    **/
+    timestamp timeout;
+};
+
+/**
+ * @exception simulation_timeout
+ *
+ * @details exception used to indicate that a UI function has received bad arguments from the user.
+**/
+class simulation_timeout : public std::exception
+{
+    public:
+        simulation_timeout(const char* msg) : message(msg) {}
+        const char* what()
+        {
+            return message;
+        }
+
+    private:
+        const char* message;
 };

--- a/csdc-6/adcs-simulation/cpp/inc/UI.hpp
+++ b/csdc-6/adcs-simulation/cpp/inc/UI.hpp
@@ -26,9 +26,6 @@
 #include "ConfigurationSingleton.hpp"
 #include "Messenger.hpp"
 
-// this is considered to be very bad practice :(
-// using namespace std;
-
 /**
  * @class   UI
  *
@@ -84,6 +81,25 @@ class UI
          *              args[2] path to the "stop conditions" YAML file
         **/
         void run_simulation(std::vector<std::string> args);
+
+        /**
+         * @name    parse_run_sim_args
+         *
+         * @details given a set of args for the simulation, parses them and applies them. Allowed
+         *          args are as follows:
+         *              input_yaml_path - path to the input yaml (required)
+         *              exit_yaml_path  - path to the output yaml (optional)
+         *              --silent        - mutes the terminal during the simulation (optional)
+         *              -- csv_rate r   - sets the csv print rate to r (ms) (optional)
+         *              -- print_rate r - sets the terminal print rate to r (ms) (optional)
+         *
+         * @param args the user input arguments. Arguments are as follows:
+         *              args[0]  command "clean_out"
+         *              args[1]  input_yaml_path
+         *              args[2]  exit_yaml_path (optional)
+         *              args[2+] optional flags
+        **/
+        void parse_run_sim_args(std::vector<std::string> args);
 
         /**
          * @name create_sensor
@@ -163,26 +179,35 @@ class UI
         /* Messenger object used to send information to the user. */
         Messenger messenger;
 
-        /* Map linking each command to it's function implementation. Used by "run_command"**/
+        /* Map linking each command to it's function implementation. Used by "run_command" */
         std::unordered_map<std::string, commandFunc> allowed_commands;
 
-        /* Flag used when the terminal has been started.**/
+        /* Flag used when the terminal has been started. */
         bool terminal_active;
 
-        /* Number of expected args for the "start_sim" command**/
-        const uint8_t num_run_simulation_args = 3;
+        /* Max number of args for the "start_sim" command */
+        const uint8_t max_run_simulation_args = 8;
 
-        /* Number of expected args for the "resume_sim" command**/
+        /* Min number of args for the "start_sim" command */
+        const uint8_t min_run_simulation_args = 2;
+
+        /* Number of expected args for the "resume_sim" command */
         const uint8_t num_resume_simulation_args = 2;
 
-        /* Number of expected args for the "exit" command**/
+        /* Number of expected args for the "exit" command */
         const uint8_t num_exit_args = 1;
 
-        /* Number of expected args for the "exit" command**/
+        /* Number of expected args for the "exit" command */
         const uint8_t num_clean_out_args = 1;
 
-        /* Path to the YAML file describing the final state of the previous simulation run.**/
+        /* Path to the YAML file describing the final state of the previous simulation run. */
         std::string previous_end_state_yaml;
+
+        /* Path to the YAML file describing the initial state of the simulation. */
+        std::string config_yaml_path = "";
+
+        /* Path to the YAML file describing the exit state of the controller. */
+        std::string exit_conditions_yaml_path = "";
 };
 
 /**

--- a/csdc-6/adcs-simulation/cpp/interface/src/ADCS_timer.cpp
+++ b/csdc-6/adcs-simulation/cpp/interface/src/ADCS_timer.cpp
@@ -17,9 +17,10 @@
 
 ADCS_timer::ADCS_timer(Simulator* sim)
 {
-    if (NULL == sim)
+    if (nullptr == sim)
     {
         /* THROW EXCEPTION**/
+        throw std::invalid_argument("SIM in ADCS_timer IS INVALID BAD BOYS");
     }
 
     this->sim = sim;

--- a/csdc-6/adcs-simulation/cpp/src/ConfigurationSingleton.cpp
+++ b/csdc-6/adcs-simulation/cpp/src/ConfigurationSingleton.cpp
@@ -88,6 +88,14 @@ bool Configuration::Load(const std::string &configFile) {
         std::cout << "YAML ERROR ON TIMESTEP: " << e.what() <<std::endl;
     }
 
+    //load timeout
+    try {
+        YAML::Node timeout = top["Timeout"];
+        timeoutInMilliseconds = timeout.as<int>();
+    } catch (YAML::Exception &e){
+        std::cout << "YAML ERROR ON TIMEOUT: " << e.what() <<std::endl;
+    }
+
     //load sensors
     try {
         YAML::Node sensors = top["Sensors"];
@@ -118,6 +126,79 @@ bool Configuration::Load(const std::string &configFile) {
         }
     } catch (YAML::Exception &e) {
         std::cout << "YAML ERROR ON ACTUATORS: " << e.what() << std::endl;
+    }
+
+    return true;
+}
+
+bool Configuration::load_exit_file(const std::string &fileName)
+{
+    /* load the yaml config file */
+    try 
+    {
+        top = YAML::LoadFile(fileName);
+    } 
+    catch (YAML::Exception &e)
+    {
+        std::cout << "YAML File Load failure for file: " << fileName << " : " << e.what() << std::endl;
+        return false;
+    }
+
+    /* get the final satellite configuration */
+    try
+    {
+        YAML::Node satellite = top["Satellite"];
+ 
+        /* loop through each axis of desired position */
+        try 
+        {
+            int i = 0;
+            for (const YAML::Node element : satellite["DesiredPosition"])
+            {
+                desiredSatellitePosition(i++) = element.as<float>();
+            }
+        }
+        catch (YAML::Exception &e)
+        {
+            std::cout << "YAML ERROR ON DesiredPosition: " << e.what() <<std::endl;
+        }
+
+        /* get the allowed jitter */
+        try 
+        {
+            YAML::Node jitter = satellite["AllowedJitter"];
+            this->allowed_jitter = jitter.as<float>();
+        }
+        catch (YAML::Exception &e)
+        {
+            std::cout << "YAML ERROR ON AllowedJitter: " << e.what() <<std::endl;
+        }
+
+        /* get the allowed required accuracy */
+        try 
+        {
+            YAML::Node accuracy = satellite["RequiredAccuracy"];
+            this->required_accuracy = accuracy.as<float>();
+        }
+        catch (YAML::Exception &e)
+        {
+            std::cout << "YAML ERROR ON RequiredAccuracy: " << e.what() <<std::endl;
+        }
+    }
+    catch (YAML::Exception &e)
+    {
+        std::cout << "YAML ERROR ON exit Satellite: " << e.what() <<std::endl;
+    }
+
+    /* get the amount of time the controller must hold the position for */
+    try
+    {
+        YAML::Node hold_time = top["HoldTime"];
+        this->required_hold_time = hold_time.as<int>();
+    }
+    catch (YAML::Exception &e)
+    {
+        std::cout << "YAML ERROR ON HoldTime: " << e.what() <<std::endl;
     }
 
     return true;

--- a/csdc-6/adcs-simulation/cpp/src/DummyController.cpp
+++ b/csdc-6/adcs-simulation/cpp/src/DummyController.cpp
@@ -1,0 +1,36 @@
+/**
+ * @file DummyController.cpp
+ *
+ * @details implements the dummy controller as defined in DummyController.hpp
+ *
+ * @authors Aidan Sheedy
+ *
+ * Last Edited
+ * 2022-11-14
+**/
+
+#include <iostream>
+
+#include "DummyController.hpp"
+
+DummyController::DummyController(ADCS_timer *timer)
+{
+    if (nullptr == timer)
+    {
+        throw std::invalid_argument("pointer to timer was null in DummyController");
+    }
+
+    this->timer = timer;
+}
+
+void DummyController::begin()
+{
+    timestamp time;
+
+    while(this->timeout > time)
+    {
+        timer->sleep(timestamp(0,1));
+    }
+
+    return;
+}

--- a/csdc-6/adcs-simulation/cpp/src/Messenger.cpp
+++ b/csdc-6/adcs-simulation/cpp/src/Messenger.cpp
@@ -137,29 +137,42 @@ void Messenger::write_csv_header(uint32_t num_reaction_wheels)
 
 void Messenger::update_simulation_state(sim_config state, timestamp time)
 {
+    terminal_write_count++;
+    csv_write_count++;
+
     // Do we need any checks on state?
 
-    // // for now just text dump - next step is graphs for each.
-    // std::cout << text_colour.reset << time.pretty_string() << "\t" << std::setprecision(4) << std::fixed;
-    // std::cout << state.satellite.theta_b.x() << ", " << state.satellite.theta_b.y() << ", " << state.satellite.theta_b.z() << ";\t";
-    // std::cout << state.satellite.omega_b.x() << ", " << state.satellite.omega_b.y() << ", " << state.satellite.omega_b.z() << ";\t";
-    // std::cout << state.satellite.alpha_b.x() << ", " << state.satellite.alpha_b.y() << ", " << state.satellite.alpha_b.z() << ";\t";
+    if ( (!silent_sim_prints) &&
+         (terminal_print_rate <= terminal_write_count) )
+    {
+        std::cout << text_colour.reset << time.pretty_string() << "\t" << std::setprecision(4) << std::fixed;
+        std::cout << state.satellite.theta_b.x() << ", " << state.satellite.theta_b.y() << ", " << state.satellite.theta_b.z() << ";\t\t";
+        std::cout << state.satellite.omega_b.x() << ", " << state.satellite.omega_b.y() << ", " << state.satellite.omega_b.z() << ";\t\t";
+        std::cout << state.satellite.alpha_b.x() << ", " << state.satellite.alpha_b.y() << ", " << state.satellite.alpha_b.z() << ";\t";
 
-    // std::cout << state.accelerometer.measurement.x() << ", " << state.accelerometer.measurement.y() << ", " << state.accelerometer.measurement.z() << ";\t";
-    // // std::cout << state.gyroscope.measurement.x()     << ", " << state.gyroscope.measurement.y()     << ", " << state.gyroscope.measurement.z() << ";";
+        std::cout << state.accelerometer.measurement.x() << ", " << state.accelerometer.measurement.y() << ", " << state.accelerometer.measurement.z() << ";\t";
+        // std::cout << state.gyroscope.measurement.x()     << ", " << state.gyroscope.measurement.y()     << ", " << state.gyroscope.measurement.z() << ";";
 
-    // for (uint32_t i = 0; i < state.reaction_wheels.size(); i++)
-    // {   
-    //     std::cout << "\t" << state.reaction_wheels.at(i).omega << ", " << state.reaction_wheels.at(i).alpha << ";";
+        for (uint32_t i = 0; i < state.reaction_wheels.size(); i++)
+        {   
+            std::cout << "\t" << state.reaction_wheels.at(i).omega << ", " << state.reaction_wheels.at(i).alpha << ";";
 
-    //     if (i < state.reaction_wheels.size() - 1)
-    //     {
-    //         std::cout << "\t";
-    //     }
-    // }
-    // std::cout << std::endl;
+            if (i < state.reaction_wheels.size() - 1)
+            {
+                std::cout << "\t";
+            }
+        }
+        std::cout << std::endl;
 
-    this->append_csv_output(state, time);
+        terminal_write_count = 0;
+    }
+
+    if (csv_print_rate <= csv_write_count)
+    {
+        this->append_csv_output(state, time);
+        csv_write_count = 0;
+    }
+
 
     return;
 }
@@ -218,5 +231,34 @@ void Messenger::clean_csv_files()
     {
         send_message("Output files already clean.");
     }
+    return;
+}
+
+void Messenger::silence_sim_prints()
+{
+    this->silent_sim_prints = true;
+    this->send_message("printouts will be silenced.");
+    return;
+}
+
+void Messenger::reset_defaults()
+{
+    this->silent_sim_prints   = default_silent_sim_prints;
+    this->csv_print_rate      = default_csv_print_rate;
+    this->terminal_print_rate = default_terminal_print_rate;
+    return;
+}
+
+void Messenger::set_csv_print_rate(uint32_t csv_rate)
+{
+    this->csv_print_rate = csv_rate;
+    this->send_message("CSV update period: " + std::to_string(this->csv_print_rate) + "ms.");
+    return;
+}
+
+void Messenger::set_terminal_print_rate(uint32_t terminal_rate)
+{
+    this->terminal_print_rate = terminal_rate;
+    this->send_message("Terminal print period: " + std::to_string(this->terminal_print_rate) + "ms.");
     return;
 }

--- a/csdc-6/adcs-simulation/cpp/src/Simulator.cpp
+++ b/csdc-6/adcs-simulation/cpp/src/Simulator.cpp
@@ -79,7 +79,7 @@ void Simulator::simulate(timestamp t) {
         this->messenger->update_simulation_state(this->system_vals, this->simulation_time);
         
         /* end simulation if the timeout is reached. */
-        if (this->timeout < this-> simulation_time)
+        if (this->timeout < this->simulation_time)
         {
             throw simulation_timeout("Timeout reached.");
         }

--- a/csdc-6/adcs-simulation/cpp/unit_tests/controller/test_1_config.yaml
+++ b/csdc-6/adcs-simulation/cpp/unit_tests/controller/test_1_config.yaml
@@ -1,0 +1,101 @@
+# file: simulator.yaml
+#
+# details: input file that outlines the satellite configuration. the simulator
+# configuration adheres to the following format:
+#
+# author: Lily de Loe
+#
+# last edited: 2022-11-04
+
+# Satellite:
+#   Moment: [3-dimensional matrix]
+#   Position: [3-dimensional vector]
+#   Velcoity: [3-dimensional vector]
+Satellite:
+  Moment: [[0.02035470141,0.00004983389,0.00021768132],
+           [0.00004983389,0.01993812272,-0.00007588037],
+           [0.00021768132,-0.00007588037,0.0053506098]]
+  Position: [0, 0, 0]
+  Velocity: [0, 0, 0]
+
+# Actuators:
+#   Name: [name of actuator]
+#     type: [actuator type], ReactionWheel
+#     Moment: [float]
+#     MaxAngVel: [float]
+#     MaxAngAccel: [float]
+#     MinAngVel: [float]
+#     MinAngAccel: [float]
+#     PollingTime: [float]
+#     Position: [3-dimensional vector]
+#     Velcoity: [3-dimensional vector]
+Actuators:
+  ReactionWheel1:
+    type: ReactionWheel
+    Moment: 0.00000925
+    MaxAngVel: 88
+    MaxAngAccel: 20
+    MinAngVel: 0
+    MinAngAccel: 0
+    PollingTime: 10
+    Position: [1.73205080757,1.73205080757,-1.73205080757]
+    AxisOfRotation: [0.577350269, 0.577350269, -0.577350269]
+    Velocity: 0
+    Acceleration: 0
+  ReactionWheel2:
+    type: ReactionWheel
+    Moment: 0.00000925
+    MaxAngVel: 88
+    MaxAngAccel: 20
+    MinAngVel: 0
+    MinAngAccel: 0
+    PollingTime: 10
+    Position: [1.73205080757,-1.73205080757,-1.73205080757]
+    AxisOfRotation: [0.577350269, -0.577350269, -0.577350269]
+    Velocity: 0
+    Acceleration: 0
+  ReactionWheel3:
+    type: ReactionWheel
+    Moment: 0.00000925
+    MaxAngVel: 88
+    MaxAngAccel: 20
+    MinAngVel: 0
+    MinAngAccel: 0
+    PollingTime: 10
+    Position: [-1.73205080757,-1.73205080757,-1.73205080757]
+    AxisOfRotation: [-0.577350269, -0.577350269, -0.577350269]
+    Velocity: 0
+    Acceleration: 0
+  ReactionWheel4:
+    type: ReactionWheel
+    Moment: 0.00000925
+    MaxAngVel: 88
+    MaxAngAccel: 20
+    MinAngVel: 0
+    MinAngAccel: 0
+    PollingTime: 10
+    Position: [-1.73205080757,1.73205080757,-1.73205080757]
+    AxisOfRotation: [-0.577350269, 0.577350269, -0.577350269]
+    Velocity: 0
+    Acceleration: 0
+
+# Sensors:
+#   Name: [name of sensor]
+#     type: [sensor type], Gyroscope, Accelerometer
+#     PollingTime: [float]
+#     Position: [3-dimensional matrix]
+Sensors:
+  Gyro1:
+    type: Gyroscope
+    PollingTime: 10
+    Position: [0,0,0]
+  Accel1:
+    type: Accelerometer
+    PollingTime: 10
+    Position: [0,0,0]
+
+# Timestep: [int], in ms
+TimeStep: 1
+
+# Timeout: [int], in ms
+Timeout: 600000

--- a/csdc-6/adcs-simulation/cpp/unit_tests/controller/test_1_exit.yaml
+++ b/csdc-6/adcs-simulation/cpp/unit_tests/controller/test_1_exit.yaml
@@ -1,0 +1,18 @@
+# file: simulator.yaml
+#
+# details: input file that outlines the desired attitude of the satellite
+#
+# author: Aidan Sheedy
+#
+# last edited: 2022-11-15
+
+# Satellite:
+#   DesiredPosition:     [3-dimensional vector<float>]
+#   MaxAbsoluteVelocity: [float]
+Satellite:
+  DesiredPosition: [0.5, 0.5, 0.5]
+  AllowedJitter: 0.1
+  RequiredAccuracy: 0.5
+
+# HoldTime: [int], in ms
+HoldTime: 1000

--- a/csdc-6/adcs-simulation/cpp/unit_tests/no_controller/unit_test_1.yaml
+++ b/csdc-6/adcs-simulation/cpp/unit_tests/no_controller/unit_test_1.yaml
@@ -12,11 +12,11 @@
 #   Position: [3-dimensional vector]
 #   Velocity: [3-dimensional vector]
 Satellite:
-  Moment: [[0.41666666666,0,0],
-           [0,0.41666666666,0],
+  Moment: [[0.16666666666,0,0],
+           [0,0.16666666666,0],
            [0,0,0.16666666666]]
   Position: [0,0,0]
-  Velocity: [2,1,3]
+  Velocity: [0,0,0]
 
 # Actuators:
 #   Name: [name of actuator]
@@ -60,5 +60,8 @@ Sensors:
     PollingTime: 10
     Position: [0,0,0]
 
-# Timestep: [float], in ms
+# Timestep: [int], in ms
 TimeStep: 1
+
+# Timeout: [int], in ms
+Timeout: 10

--- a/csdc-6/adcs-simulation/cpp/unit_tests/no_controller/unit_test_2.yaml
+++ b/csdc-6/adcs-simulation/cpp/unit_tests/no_controller/unit_test_2.yaml
@@ -12,11 +12,11 @@
 #   Position: [3-dimensional vector]
 #   Velocity: [3-dimensional vector]
 Satellite:
-  Moment: [[0.41666666666,0,0],
-           [0,0.41666666666,0],
+  Moment: [[0.16666666666,0,0],
+           [0,0.16666666666,0],
            [0,0,0.16666666666]]
   Position: [0,0,0]
-  Velocity: [2,1,0]
+  Velocity: [2,0,0]
 
 # Actuators:
 #   Name: [name of actuator]
@@ -60,5 +60,8 @@ Sensors:
     PollingTime: 10
     Position: [0,0,0]
 
-# Timestep: [float], in ms
+# Timestep: [int], in ms
 TimeStep: 1
+
+# Timeout: [int], in ms
+Timeout: 10

--- a/csdc-6/adcs-simulation/cpp/unit_tests/no_controller/unit_test_3.yaml
+++ b/csdc-6/adcs-simulation/cpp/unit_tests/no_controller/unit_test_3.yaml
@@ -16,7 +16,7 @@ Satellite:
            [0,0.16666666666,0],
            [0,0,0.16666666666]]
   Position: [0,0,0]
-  Velocity: [2,0,0]
+  Velocity: [2,1,0]
 
 # Actuators:
 #   Name: [name of actuator]
@@ -60,5 +60,8 @@ Sensors:
     PollingTime: 10
     Position: [0,0,0]
 
-# Timestep: [float], in ms
+# Timestep: [int], in ms
 TimeStep: 1
+
+# Timeout: [int], in ms
+Timeout: 10

--- a/csdc-6/adcs-simulation/cpp/unit_tests/no_controller/unit_test_4.yaml
+++ b/csdc-6/adcs-simulation/cpp/unit_tests/no_controller/unit_test_4.yaml
@@ -16,7 +16,7 @@ Satellite:
            [0,0.41666666666,0],
            [0,0,0.16666666666]]
   Position: [0,0,0]
-  Velocity: [2,1,3]
+  Velocity: [2,1,0]
 
 # Actuators:
 #   Name: [name of actuator]
@@ -34,16 +34,16 @@ Satellite:
 Actuators:
   ReactionWheel1:
     type: ReactionWheel
-    Moment: 2
+    Moment: 1
     MaxAngVel: 1000
     MaxAngAccel: 1000
     MinAngVel: 0
     MinAngAccel: 0
     PollingTime: 10
     Position: [0,0,0]
-    Velocity: 2.5
+    Velocity: 1
     AxisOfRotation: [0,0,1]
-    Acceleration: 0.5
+    Acceleration: 1
 
 # Sensors:
 #   Name: [name of sensor]
@@ -60,5 +60,8 @@ Sensors:
     PollingTime: 10
     Position: [0,0,0]
 
-# Timestep: [float], in ms
+# Timestep: [int], in ms
 TimeStep: 1
+
+# Timeout: [int], in ms
+Timeout: 10

--- a/csdc-6/adcs-simulation/cpp/unit_tests/no_controller/unit_test_5.yaml
+++ b/csdc-6/adcs-simulation/cpp/unit_tests/no_controller/unit_test_5.yaml
@@ -12,11 +12,11 @@
 #   Position: [3-dimensional vector]
 #   Velocity: [3-dimensional vector]
 Satellite:
-  Moment: [[0.16666666666,0,0],
-           [0,0.16666666666,0],
+  Moment: [[0.41666666666,0,0],
+           [0,0.41666666666,0],
            [0,0,0.16666666666]]
   Position: [0,0,0]
-  Velocity: [2,1,0]
+  Velocity: [2,1,3]
 
 # Actuators:
 #   Name: [name of actuator]
@@ -60,5 +60,8 @@ Sensors:
     PollingTime: 10
     Position: [0,0,0]
 
-# Timestep: [float], in ms
+# Timestep: [int], in ms
 TimeStep: 1
+
+# Timeout: [int], in ms
+Timeout: 10

--- a/csdc-6/adcs-simulation/cpp/unit_tests/no_controller/unit_test_6.yaml
+++ b/csdc-6/adcs-simulation/cpp/unit_tests/no_controller/unit_test_6.yaml
@@ -12,11 +12,11 @@
 #   Position: [3-dimensional vector]
 #   Velocity: [3-dimensional vector]
 Satellite:
-  Moment: [[0.16666666666,0,0],
-           [0,0.16666666666,0],
+  Moment: [[0.41666666666,0,0],
+           [0,0.41666666666,0],
            [0,0,0.16666666666]]
   Position: [0,0,0]
-  Velocity: [0,0,0]
+  Velocity: [2,1,3]
 
 # Actuators:
 #   Name: [name of actuator]
@@ -34,16 +34,16 @@ Satellite:
 Actuators:
   ReactionWheel1:
     type: ReactionWheel
-    Moment: 1
+    Moment: 2
     MaxAngVel: 1000
     MaxAngAccel: 1000
     MinAngVel: 0
     MinAngAccel: 0
     PollingTime: 10
     Position: [0,0,0]
-    Velocity: 1
+    Velocity: 2.5
     AxisOfRotation: [0,0,1]
-    Acceleration: 1
+    Acceleration: 0.5
 
 # Sensors:
 #   Name: [name of sensor]
@@ -60,5 +60,8 @@ Sensors:
     PollingTime: 10
     Position: [0,0,0]
 
-# Timestep: [float], in ms
+# Timestep: [int], in ms
 TimeStep: 1
+
+# Timeout: [int], in ms
+Timeout: 10


### PR DESCRIPTION
CHANGES
- created a second YAML template for setting parameters for the controller
- expanded "start_sim" command in UI -> command can now take: 
  - one or two yaml files (one will just run a dummy controller, two will run the regular controller with supplied params) 
  - "-s" or "--silent" will mute all printouts during the run 
  - "-c" or "--csv_rate" + "rate" will set the csv print rate to the supplied parameter (in ms) 
  - "-p" or "--print_rate" + "rate" will set the terminal print rate to the supplied parameter (in ms)
- added parsing of the new YAML to the configuration singleton (also made some minor changes to types, some floats should be ints)
- created a dummy controller class, which just loops over a timer requesting the system to sleep until a max timeout of 1 hour (sim time)
- added functionality in the Messenger to update the terminal or csv file at rates specified by the "-p" and "-c" flags respectively
- added timeout to the simulator. Once the timeout is reached, a "simulation_timeout" exception is thrown, to be caught by the UI class
- some other minor fixes

REASON
Second yaml allows the controller information to be setup by the user in a config file.

TESTING
All unit tests run as expected.
All new commands work as expected.
Dummy controller and actual controller behave as expected.

Signed-off-by: Aidan Sheedy <Aidan.P.Sheedy@gmail.com>