### PR TITLE
adcs-66 update output file to use a buffer

### DIFF
--- a/csdc-6/.gitignore
+++ b/csdc-6/.gitignore
@@ -7,3 +7,4 @@ Makefile
 bin/
 output/
 cmake_install.cmake
+plots/

--- a/csdc-6/adcs-simulation/cpp/.gitattributes
+++ b/csdc-6/adcs-simulation/cpp/.gitattributes
@@ -3,3 +3,4 @@
 
 # Set bash scripts to use lf for wsl
 *.sh text eol=lf
+*.py text eol=lf

--- a/csdc-6/adcs-simulation/cpp/inc/ConfigurationSingleton.hpp
+++ b/csdc-6/adcs-simulation/cpp/inc/ConfigurationSingleton.hpp
@@ -59,9 +59,9 @@ struct ActuatorConfig {
 * @details struct outling the configuration of a gryoscope according to the input YAML
 * parameters
 */
-struct GyroConfig : public SensorConfig {
-    GyroConfig(const YAML::Node &node);
-
+struct GyroConfig : public SensorConfig
+{
+    GyroConfig(const YAML::Node &node) : SensorConfig(SensorType::Gyroscope, node) {}
 };
 
 /**
@@ -70,9 +70,9 @@ struct GyroConfig : public SensorConfig {
 * @details struct outling the configuration of an accelerometer according to the input YAML
 * parameters
 */
-struct AccelerometerConfig : public SensorConfig {
-    AccelerometerConfig(const YAML::Node &node);
-
+struct AccelerometerConfig : public SensorConfig
+{
+    AccelerometerConfig(const YAML::Node &node) : SensorConfig(SensorType::Accelerometer, node) {}
 };
 
 /**

--- a/csdc-6/adcs-simulation/cpp/inc/Messenger.hpp
+++ b/csdc-6/adcs-simulation/cpp/inc/Messenger.hpp
@@ -187,32 +187,53 @@ class Messenger
         }
 
         /**
-         * @name    set_terminal_print_rate
+         * @name    silence_csv
          *
-         * @details sets the print rate to the terminal in terms of simulation time.
-         *
-         * @param   csv_rate [uint32_t] the timestep in ms that the terminal will be updated
+         * @details prevents any outputs to the csv file during the simulation
         **/
         void silence_csv();
 
         /**
-         * @name    close_open_csv
-         *
-         * @details closes the CSV file if open.
-        **/
-        void close_open_csv();
+         * @name    write_output_buffer
+         * 
+         * @details saves the file buffer to a new csv file
+        */
+        void write_output_buffer();
 
     private:
         /**
+         * @name    write_cout_header
+         * 
+         * @details writes a header to the terminal for the simulation run
+         * 
+         * @param   num_reaction_wheels the number of reaction wheels used. This is necessary for
+         *                              the number of columns to print.
+        **/
+        void write_cout_header(uint32_t num_reaction_wheels);
+
+        /**
+         * @name    write_csv_header
+         * 
+         * @details writes a header to the csv file for the simulation run
+         * 
+         * @param   num_reaction_wheels the number of reaction wheels used. This is necessary for
+         *                              the number of columns to print.
+        **/
+        void write_csv_header(uint32_t num_reaction_wheels);
+
+        /**
          * @name    append_csv_output
          *
-         * @details appends a simulation state to the end of the csv output file.
+         * @details appends a simulation state to the csv output buffer.
         **/
         void append_csv_output(sim_config state, timestamp time);
 
-        void write_cout_header(uint32_t num_reaction_wheels);
-
-        void write_csv_header(uint32_t num_reaction_wheels);
+        /**
+         * @name    append_cout_output
+         * 
+         * @details appends a simulation state to the terminal.
+        **/
+        void append_cout_output(sim_config state, timestamp time);
 
     private:
         /* Character used to denote user control of the terminal.**/
@@ -266,9 +287,8 @@ class Messenger
         **/
         uint32_t terminal_write_count = 0;
 
-        /* CSV file to write logs to */
-        std::ofstream open_output_file;
-
+        /* Buffer variable for the simulation output data. */
+        std::stringstream output_file_buffer;
 };
 
 /**

--- a/csdc-6/adcs-simulation/cpp/inc/UI.hpp
+++ b/csdc-6/adcs-simulation/cpp/inc/UI.hpp
@@ -122,15 +122,15 @@ class UI
          *
          * @details creates an actuator object and populates it in an unordered map to be used by the
          *          control code.
-        **/  
+        **/
         void create_actuator(const std::string &name, Simulator *sim, std::unordered_map<std::string, std::shared_ptr<Actuator>> *actuators);
 
         /**
          * @name get_sim_config
-         * 
+         *
          * @param config configuration singleton used to get the simulation initial parameters.
-         * 
-         * @returns the initial configuration fo the satellite 
+         *
+         * @returns the initial configuration fo the satellite
         **/
         sim_config get_sim_config(Configuration &config);
 
@@ -171,7 +171,7 @@ class UI
          * @name    run_unit_tests
          *
          * @details Input command to run all the unit or specified unit tests.
-         * 
+         *
          * @note    for now this only runs all unit tests - future functionality may be added to
          *          specify tests to run
          *
@@ -210,6 +210,31 @@ class UI
         **/
         void run_perf_tests(std::vector<std::string> args);
 
+        /**
+         * @name    plot_simulation_results
+         *
+         * @details plots the simulation results from the csv_path provided
+         *
+         * @param   csv_path the path to the results to plot
+        **/
+        void plot_simulation_results(std::string csv_path);
+
+        /**
+         * @name    reset_simulation_argument_defaults
+         *
+         * @details resets the simulation parameters to their defaults
+        **/
+        void reset_simulation_argument_defaults();
+
+        /**
+         * @name    clean_plots
+         *
+         * @details deletes all plots in the plots folder
+         *
+         * @param args the user input arguments. There should be none.
+        */
+        void clean_plots(std::vector<std::string> args);
+
     private:
         /**
          * @typedef UI::*commandFunc
@@ -229,7 +254,7 @@ class UI
         bool terminal_active;
 
         /* Max number of args for the "start_sim" command */
-        const uint8_t max_run_simulation_args = 8;
+        const uint8_t max_run_simulation_args = 9;
 
         /* Min number of args for the "start_sim" command */
         const uint8_t min_run_simulation_args = 2;
@@ -248,6 +273,9 @@ class UI
 
         /* Number of expected args for the "perf_test" command */
         const uint8_t num_perf_test_args = 1;
+
+        /* Number of expected args for the "clean_plots" command */
+        const uint8_t num_clean_plots_args = 1;
 
         /* Path where yamls describing unit tests are expected */
         const std::string expected_no_controller_unit_test_dir = "unit_tests/no_controller/";
@@ -276,11 +304,14 @@ class UI
         /* unit test name prefix for the sim exit yaml (without the number) */
         const std::string controller_test_output_name = "unit_test_out_";
 
+        /* path to the perfomance test config yaml file (without the number or file extension) */
         const std::string perf_test_config_yaml_path = "unit_tests/performance/perf_test_config_";
 
+        /* path to the perfomance test exit yaml file (without the number or file extension) */
         const std::string perf_test_exit_yaml_path = "unit_tests/performance/perf_test_exit_";
 
-        const std::vector<std::string> perf_test_descriptions = 
+        /* Description of each performance test */
+        const std::vector<std::string> perf_test_descriptions =
         {
             "No initial velocity, requested postion = stationary",
             "Some initial velocity, requested postion = stationary",
@@ -288,6 +319,12 @@ class UI
             "Test 3 + reduced csv writes",
             "test 3 + no csv writes"
         };
+
+        /* directory of the plotting script */
+        const std::string python_plot_file_dir = "./results_visualization.py";
+
+        /* directory of the plotting output */
+        const std::string plot_dir = "./plots";
 
         /* number of performance tests to run */
         const uint8_t num_performance_tests = 5;
@@ -297,6 +334,12 @@ class UI
 
         /* number of unit tests to run with the controller */
         const uint8_t num_controller_unit_tests = 3;
+
+        /* default value of the silent plots flag */
+        const bool default_silent_plots = false;
+
+        /* flag to indicate if results should be plotted. */
+        bool silent_plots = false;
 
         /* Path to the YAML file describing the final state of the previous simulation run. */
         std::string previous_end_state_yaml;

--- a/csdc-6/adcs-simulation/cpp/interface/inc/sim_interface.hpp
+++ b/csdc-6/adcs-simulation/cpp/interface/inc/sim_interface.hpp
@@ -118,22 +118,6 @@ class Sensor : public ADCS_device {
         virtual ~Sensor(){}
 
         /**
-         * @note commenting out for now but this may need to be removed entirely. Keeping until a decision is made.
-         * 
-         * @name    take_measurement
-         *
-         * @details this function takes a measurement using the sensor. The simulation is also told
-         *          to update.
-         *
-         * @returns the required measurement if succesful.
-        **/
-        // virtual measurement take_measurement() // MAY need to create a default implementation
-        // {
-        //     measurement empty;
-        //     return empty;
-        // } 
-
-        /**
          * @name    set_current_vals
          *
          * @details this function sets the new raw sensor values from the simulation and calculates

--- a/csdc-6/adcs-simulation/cpp/interface/src/Reaction_wheel.cpp
+++ b/csdc-6/adcs-simulation/cpp/interface/src/Reaction_wheel.cpp
@@ -21,7 +21,7 @@ Reaction_wheel::Reaction_wheel(timestamp polling_time, Simulator* sim, Eigen::Ve
 
     if(inertia_matrix == 0)
     {
-        std::cout << "YEEEET" << std::endl;
+        throw invalid_adcs_param("Reaction wheel inertia is 0. (YEET was not succesful)");
     }
 
     this->inertia_matrix = inertia_matrix;

--- a/csdc-6/adcs-simulation/cpp/results_visualization.py
+++ b/csdc-6/adcs-simulation/cpp/results_visualization.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python3
 
 import sys
+import os
+import re
 import pandas as pd
 import matplotlib.pyplot as plt
 
-def plot_results(csv_name):
+def plot_results(csv_name, outpath):
     data = pd.read_csv(csv_name)
     time = data['Time']
 
@@ -20,7 +22,7 @@ def plot_results(csv_name):
     plt.plot(time, theta_y, label="y")
     plt.plot(time, theta_z, label="z")
     plt.legend()
-    plt.savefig('plots/Satellite_Position_vs_Time.png')
+    plt.savefig(outpath + '/Satellite_Position_vs_Time.png')
 
     omega_x = data['Satellite Omega x']
     omega_y = data['Satellite Omega y']
@@ -34,7 +36,7 @@ def plot_results(csv_name):
     plt.plot(time, omega_y, label="y")
     plt.plot(time, omega_z, label="z")
     plt.legend()
-    plt.savefig('plots/Satellite_Velocity_vs_Time.png')
+    plt.savefig(outpath + '/Satellite_Velocity_vs_Time.png')
 
     alpha_x = data['Satellite alpha x']
     alpha_y = data['Satellite alpha y']
@@ -48,7 +50,7 @@ def plot_results(csv_name):
     plt.plot(time, alpha_y, label="y")
     plt.plot(time, alpha_z, label="z")
     plt.legend()
-    plt.savefig('plots/Satellite_Acceleration_vs_Time.png')
+    plt.savefig(outpath + '/Satellite_Acceleration_vs_Time.png')
 
     accel_x = data['Accelerometer x']
     accel_y = data['Accelerometer y']
@@ -62,7 +64,7 @@ def plot_results(csv_name):
     plt.plot(time, accel_y, label="y")
     plt.plot(time, accel_z, label="z")
     plt.legend()
-    plt.savefig('plots/Accelerometer_Reading_vs_Time.png')
+    plt.savefig(outpath + '/Accelerometer_Reading_vs_Time.png')
 
     wheel_count = len([col for col in data.columns if "Reaction wheel" in col]) // 2
     for i in range(wheel_count):
@@ -75,12 +77,19 @@ def plot_results(csv_name):
         plt.plot(time, rw_omega, label="omega")
         plt.plot(time, rw_alpha, label="alpha")
         plt.legend()
-        plt.savefig('plots/Reaction wheel %d alpha.png' %(i+1))
+        plt.savefig(outpath + '/Reaction wheel %d alpha.png' %(i+1))
 
 
 def main():
     filepath = sys.argv[1]
-    plot_results(filepath)
+    if (not os.path.exists('plots')):
+        os.mkdir('plots')
+    filename = re.search('output/(.*).csv', filepath)
+    outpath = 'plots/' + filename.group(1)
+    if (not os.path.exists(outpath)):
+        os.mkdir(outpath)
+
+    plot_results(filepath, outpath)
 
 if __name__ == "__main__":
     main()

--- a/csdc-6/adcs-simulation/cpp/src/ConfigurationSingleton.cpp
+++ b/csdc-6/adcs-simulation/cpp/src/ConfigurationSingleton.cpp
@@ -13,14 +13,6 @@
 #include "ConfigurationSingleton.hpp"
 #include <iostream>
 
-GyroConfig::GyroConfig(const YAML::Node &node) : SensorConfig(SensorType::Gyroscope, node) {
-
-}
-
-AccelerometerConfig::AccelerometerConfig(const YAML::Node &node) : SensorConfig(SensorType::Accelerometer, node) {
-
-}
-
 ReactionWheelConfig::ReactionWheelConfig(const YAML::Node &node) : ActuatorConfig(ActuatorType::ReactionWheel) {
     momentOfInertia = node["Moment"].as<float>();
 

--- a/csdc-6/adcs-simulation/cpp/src/Simulator.cpp
+++ b/csdc-6/adcs-simulation/cpp/src/Simulator.cpp
@@ -78,7 +78,7 @@ void Simulator::simulate(timestamp t) {
         /* end simulation if the timeout is reached. */
         if (this->timeout < this->simulation_time)
         {
-            this->messenger->close_open_csv();
+            this->messenger->write_output_buffer();
             throw simulation_timeout("Timeout reached.");
         }
     }


### PR DESCRIPTION
CHANGES
- Updated the file output system to write it as a buffer at the end instead of throughout the simulation
- Updated missing documentation in Messenger.hpp

- Updated gitignore to ignore ploted figures
- Updated gitattributes to allow python files to use just "LF"
- Minor cleanup in configuration singleton
- Cleaned up unused code
- Added functionality to put plots in a folder with the same name as the csv file

REASON
Good practice is to only write to a file once, which requires keeping a buffer of the output instead of writing to the file multiple times.

TESTING
All unit tests pass, output buffer works as expected.

GITHUB LINK
https://github.com/queens-satellite-team/adcs/issues/66

Signed-off-by: Aidan Sheedy <Aidan.P.Sheedy@gmail.com>