### PR TITLE
adcs-66 implement variable timestep

### DIFF
--- a/csdc-6/adcs-simulation/cpp/inc/ConfigurationSingleton.hpp
+++ b/csdc-6/adcs-simulation/cpp/inc/ConfigurationSingleton.hpp
@@ -235,6 +235,36 @@ public:
     }
 
     /**
+    * @name GetTimestepDecision
+    * @return whether or not to use variable timestep
+    * 
+    * @details getter for the timestep method
+    */
+    inline const bool &GetTimestepDecision(){
+        return useVariableTimestep;
+    }
+
+    /**
+    * @name GetMaxTimestep
+    * @return whether or not to use variable timestep
+    * 
+    * @details getter for the timestep method
+    */
+    inline const float &GetMaxTimestep(){
+        return timeStepMax;
+    }
+
+    /**
+    * @name GetMinTimestep
+    * @return whether or not to use variable timestep
+    * 
+    * @details getter for the timestep method
+    */
+    inline const float &GetMinTimestep(){
+        return timeStepMin;
+    }
+
+    /**
     * @name    getTimeout
     * 
     * @returns the timeout, in seconds, as a float
@@ -331,9 +361,24 @@ private:
     int timestepInMilliSeconds;
 
     /**
-     * @details float storing the timeout in milliseconds
+     * @details int storing the timeout in milliseconds
     */
     int timeoutInMilliseconds;
+
+    /**
+     * @details bool storing whether or not to use variable timestep
+    */
+    bool useVariableTimestep;
+
+    /**
+     * @details max timestep allowed for the calculated variable timestep
+    */
+    float timeStepMax;
+
+    /**
+     * @details min timestep allowed for the calculated variable timestep
+    */
+    float timeStepMin;
 
     /* the desired satellite position for the controller */
     Eigen::Vector3f desiredSatellitePosition;

--- a/csdc-6/adcs-simulation/cpp/inc/Messenger.hpp
+++ b/csdc-6/adcs-simulation/cpp/inc/Messenger.hpp
@@ -255,10 +255,10 @@ class Messenger
         const bool default_silent_csv_prints = false;
 
         /* default print rate to the csv file in ms */
-        const uint32_t default_csv_print_rate = 1;
+        const timestamp default_csv_print_rate = timestamp(1,0);
 
         /* default print rate to the terminal in ms */
-        const uint32_t default_terminal_print_rate = 10;
+        const timestamp default_terminal_print_rate = timestamp(10,0);
 
         /* full string of the output path */
         std::string output_file_path_string = "";
@@ -270,22 +270,16 @@ class Messenger
         bool silent_csv_prints = false;
 
         /* print rate to the csv file in ms */
-        uint32_t csv_print_rate = 1;
+        timestamp csv_print_rate = timestamp(1,0);
 
         /* print rate to the terminal in ms */
-        uint32_t terminal_print_rate = 10;
+        timestamp terminal_print_rate = timestamp(10,0);
 
-        /**
-         * number of attempts to write to csv. Each count corresponds to 1 ms, and gets reset when
-         * it reaches csv_print_rate
-        **/
-        uint32_t csv_write_count = 0;
+        /* Previous time the csv was updated */
+        timestamp previous_csv_write = 0;
 
-        /**
-         * number of attempts to write to the terminal. Each count corresponds to 1 ms, and gets
-         * reset when it reaches csv_print_rate
-        **/
-        uint32_t terminal_write_count = 0;
+        /* Previous time the terminal was updated */
+        timestamp previous_terminal_write = 0;
 
         /* Buffer variable for the simulation output data. */
         std::stringstream output_file_buffer;

--- a/csdc-6/adcs-simulation/cpp/inc/Messenger.hpp
+++ b/csdc-6/adcs-simulation/cpp/inc/Messenger.hpp
@@ -95,7 +95,7 @@ class Messenger
          *              acceleration.
          * @param time  time of the update.
         **/
-        void update_simulation_state(sim_config state, timestamp time);
+        void update_simulation_state(sim_config state, timestamp time, timestamp timestep);
 
         /**
          * @name    prompt_char
@@ -226,14 +226,14 @@ class Messenger
          *
          * @details appends a simulation state to the csv output buffer.
         **/
-        void append_csv_output(sim_config state, timestamp time);
+        void append_csv_output(sim_config state, timestamp time, timestamp timestep);
 
         /**
          * @name    append_cout_output
          * 
          * @details appends a simulation state to the terminal.
         **/
-        void append_cout_output(sim_config state, timestamp time);
+        void append_cout_output(sim_config state, timestamp time, timestamp timestep);
 
     private:
         /* Character used to denote user control of the terminal.**/

--- a/csdc-6/adcs-simulation/cpp/inc/Simulator.hpp
+++ b/csdc-6/adcs-simulation/cpp/inc/Simulator.hpp
@@ -42,7 +42,7 @@ public:
     *
     * @details Initializes the simulation with starting values.
    **/
-    void init(sim_config initial_values, timestamp timeout);
+    void init(sim_config initial_values, timestamp timeout, timestamp initial_timestep, bool variableTimestep, timestamp max_timestep, timestamp min_timestep);
 
     /**
     * @name update_simulation
@@ -156,6 +156,9 @@ private:
     timestamp determine_time_passed();
 
 private:
+    /* max error allowed per timestep in position accuracy - the first term is in degrees */
+    const float max_error_in_rad = 0.00005 * M_PI / 180;
+
     /**
      * @property simulation_time [timestamp]
      *
@@ -193,14 +196,14 @@ private:
      *
      * @details max allowed timestep from user
     **/
-    float maxStep;
+    timestamp max_timestep;
 
     /**
      * @property minStep [float]
      *
      * @details min allowed timestep from user
     **/
-    float minStep;
+    timestamp min_timestamp;
 
     /**
      * @property system_vals [sim_config]

--- a/csdc-6/adcs-simulation/cpp/inc/Simulator.hpp
+++ b/csdc-6/adcs-simulation/cpp/inc/Simulator.hpp
@@ -6,7 +6,7 @@
  * @authors Lily de Loe, Justin Paoli, Aidan Sheedy
  *
  * Last Edited
- * 2022-11-18
+ * 2022-12-01
  *
 **/
 
@@ -53,6 +53,14 @@ public:
     * up to date values for a sensor
    **/
     timestamp update_simulation();
+
+    /**
+    * @name determine_timestep
+    * @returns [timestamp], the newly calculated timestep
+    *
+    * @details Updates the desired timestep
+    * */
+    timestamp determine_timestep();
 
     /**
     * @name set_adcs_sleep
@@ -172,6 +180,27 @@ private:
      * by the simualor will advance the simulation time by this amount.
     **/
     timestamp timestep_length;
+
+    /**
+     * @property timestep [bool]
+     *
+     * @details either TRUE (variable timestep) or FALSE (fixed timestep)
+    **/
+    bool variableTimestep;
+
+    /**
+     * @property maxStep [float]
+     *
+     * @details max allowed timestep from user
+    **/
+    float maxStep;
+
+    /**
+     * @property minStep [float]
+     *
+     * @details min allowed timestep from user
+    **/
+    float minStep;
 
     /**
      * @property system_vals [sim_config]

--- a/csdc-6/adcs-simulation/cpp/inc/Simulator.hpp
+++ b/csdc-6/adcs-simulation/cpp/inc/Simulator.hpp
@@ -28,50 +28,50 @@
 class Simulator {
 public:
     /**
-    * @class Simulator
-    * @param configFile [string], the filename of the YAML config file
-    *
-    * @details constructor for the simulator class. Calls the configuration
-    * singleton to instantiate all of the sensors and actuators present in the
-    * simulation based on the properties of the provided YAML configuration file.
-   **/
+     * @class Simulator
+     * @param configFile [string], the filename of the YAML config file
+     *
+     * @details constructor for the simulator class. Calls the configuration
+     * singleton to instantiate all of the sensors and actuators present in the
+     * simulation based on the properties of the provided YAML configuration file.
+    **/
     Simulator(Messenger *messenger);
 
     /**
-    * @name init
-    *
-    * @details Initializes the simulation with starting values.
-   **/
+     * @name init
+     *
+     * @details Initializes the simulation with starting values.
+    **/
     void init(sim_config initial_values, timestamp timeout, timestamp initial_timestep, bool variableTimestep, timestamp max_timestep, timestamp min_timestep);
 
     /**
-    * @name update_simulation
-    * @returns [timestamp], the simulation time at the end of calculations
-    *
-    * @details Updates the simulation based on the amount of time the
-    * control code spent running. Used when the control code requests
-    * up to date values for a sensor
-   **/
+     * @name update_simulation
+     * @returns [timestamp], the simulation time at the end of calculations
+     *
+     * @details Updates the simulation based on the amount of time the
+     * control code spent running. Used when the control code requests
+     * up to date values for a sensor
+    **/
     timestamp update_simulation();
 
     /**
-    * @name determine_timestep
-    * @returns [timestamp], the newly calculated timestep
-    *
-    * @details Updates the desired timestep
-    * */
-    timestamp determine_timestep();
+     * @name determine_timestep
+     *
+     * @details Updates the desired timestep based on an error equation. Restricts the timestep to
+     *          be within the min and max described in the YAML.
+    **/
+    void determine_timestep();
 
     /**
-    * @name set_adcs_sleep
-    * @param duration [timestamp], the additional time to simulate
-    * @returns [timestamp], the simulation time at the end of calculations
-    *
-    * @details Updates the simulation based on the amount of time the
-    * control code spent running plus some additional specified time.
-    * Used when the control code is not ready for new sensor data and
-    * intends to sleep until new data can be processed.
-   **/
+     * @name set_adcs_sleep
+     * @param duration [timestamp], the additional time to simulate
+     * @returns [timestamp], the simulation time at the end of calculations
+     *
+     * @details Updates the simulation based on the amount of time the
+     * control code spent running plus some additional specified time.
+     * Used when the control code is not ready for new sensor data and
+     * intends to sleep until new data can be processed.
+    **/
     timestamp set_adcs_sleep(timestamp duration);
 
     /**

--- a/csdc-6/adcs-simulation/cpp/results_visualization.py
+++ b/csdc-6/adcs-simulation/cpp/results_visualization.py
@@ -5,6 +5,7 @@ import os
 import re
 import pandas as pd
 import matplotlib.pyplot as plt
+import webbrowser
 
 def plot_results(csv_name, outpath):
     data = pd.read_csv(csv_name)
@@ -13,11 +14,11 @@ def plot_results(csv_name, outpath):
     timestep = data['Timestep']*1000
 
     plt.figure(1)
-    plt.title("Satellite Position vs. Time")
+    plt.title("Timestep vs. Time")
     plt.xlabel("Time [s]")
     plt.ylabel("Timestep [ms]")
     plt.plot(time, timestep)
-    plt.savefig(outpath + '/Tiemstep_vs_Time.png')
+    plt.savefig(outpath + '/Timestep_vs_Time.png')
 
     theta_x = data['Satellite theta x']
     theta_y = data['Satellite theta y']
@@ -32,6 +33,7 @@ def plot_results(csv_name, outpath):
     plt.plot(time, theta_z, label="z")
     plt.legend()
     plt.savefig(outpath + '/Satellite_Position_vs_Time.png')
+    webbrowser.open(outpath + '/Satellite_Position_vs_Time.png')
 
     
 

--- a/csdc-6/adcs-simulation/cpp/results_visualization.py
+++ b/csdc-6/adcs-simulation/cpp/results_visualization.py
@@ -10,11 +10,20 @@ def plot_results(csv_name, outpath):
     data = pd.read_csv(csv_name)
     time = data['Time']
 
+    timestep = data['Timestep']*1000
+
+    plt.figure(1)
+    plt.title("Satellite Position vs. Time")
+    plt.xlabel("Time [s]")
+    plt.ylabel("Timestep [ms]")
+    plt.plot(time, timestep)
+    plt.savefig(outpath + '/Tiemstep_vs_Time.png')
+
     theta_x = data['Satellite theta x']
     theta_y = data['Satellite theta y']
     theta_z = data['Satellite theta z']
 
-    plt.figure(1)
+    plt.figure(2)
     plt.title("Satellite Position vs. Time")
     plt.xlabel("Time [s]")
     plt.ylabel("Satellite Position [rad]")
@@ -24,11 +33,13 @@ def plot_results(csv_name, outpath):
     plt.legend()
     plt.savefig(outpath + '/Satellite_Position_vs_Time.png')
 
+    
+
     omega_x = data['Satellite Omega x']
     omega_y = data['Satellite Omega y']
     omega_z = data['Satellite Omega z']
 
-    plt.figure(2)
+    plt.figure(3)
     plt.title("Satellite Velocity vs. Time")
     plt.xlabel("Time [s]")
     plt.ylabel("Satellite Velocity [rad/s]")
@@ -42,7 +53,7 @@ def plot_results(csv_name, outpath):
     alpha_y = data['Satellite alpha y']
     alpha_z = data['Satellite alpha z']
 
-    plt.figure(3)
+    plt.figure(4)
     plt.title("Satellite Acceleration vs. Time")
     plt.xlabel("Time [s]")
     plt.ylabel("Satellite Acceleration [rad/s^2]")
@@ -56,7 +67,7 @@ def plot_results(csv_name, outpath):
     accel_y = data['Accelerometer y']
     accel_z = data['Accelerometer z']
 
-    plt.figure(4)
+    plt.figure(5)
     plt.title("Accelerometer Reading vs. Time")
     plt.xlabel("Time [s]")
     plt.ylabel("Accelerometer [m/s^2]")
@@ -68,7 +79,7 @@ def plot_results(csv_name, outpath):
 
     wheel_count = len([col for col in data.columns if "Reaction wheel" in col]) // 2
     for i in range(wheel_count):
-        plt.figure(5+i)
+        plt.figure(6+i)
         rw_omega = data['Reaction wheel %d Omega' % i]
         rw_alpha = data['Reaction wheel %d alpha' % i]
 

--- a/csdc-6/adcs-simulation/cpp/src/ConfigurationSingleton.cpp
+++ b/csdc-6/adcs-simulation/cpp/src/ConfigurationSingleton.cpp
@@ -72,12 +72,34 @@ bool Configuration::Load(const std::string &configFile) {
         std::cout << "YAML ERROR ON SATELLITE STATE: " << e.what() <<std::endl;
     }
 
-    //load input timestep
+    //load condition for variable timestep
     try {
-        YAML::Node time = top["TimeStep"];
-        timestepInMilliSeconds = time.as<float>();
+        YAML::Node variableTimestep = top["VariableTimestep"];
+        useVariableTimestep = variableTimestep.as<bool>();
     } catch (YAML::Exception &e){
-        std::cout << "YAML ERROR ON TIMESTEP: " << e.what() <<std::endl;
+        std::cout << "YAML ERROR ON VARIABLE TIMESTEP: " << e.what() <<std::endl;
+    }
+
+    if (useVariableTimestep == true) {
+    //load max and min timestep
+        try {
+            YAML::Node max = top["TimeStepMax"];
+            timeStepMax = max.as<int>();
+            YAML::Node min = top["TimeStepMin"];
+            timeStepMin = min.as<int>();
+        } catch (YAML::Exception &e){
+            std::cout << "YAML ERROR ON TIMESTEP BOUNDS: " << e.what() <<std::endl;
+        }
+    }
+    else
+    {
+        //load input timestep
+        try {
+            YAML::Node time = top["TimeStep"];
+            timestepInMilliSeconds = time.as<float>();
+        } catch (YAML::Exception &e){
+            std::cout << "YAML ERROR ON TIMESTEP: " << e.what() <<std::endl;
+        }
     }
 
     //load timeout

--- a/csdc-6/adcs-simulation/cpp/src/Messenger.cpp
+++ b/csdc-6/adcs-simulation/cpp/src/Messenger.cpp
@@ -76,7 +76,7 @@ void Messenger::write_cout_header(uint32_t num_reaction_wheels)
 {
     if(!silent_sim_prints)
     {
-        std::cout << text_colour.magenta << "Time" << "\t\t";
+        std::cout << text_colour.magenta << "Time" << "\t\t" << "Timestep" << "\t\t";
         std::cout << "Sat tx, Sat ty, Sat tz;\t\t" << "Sat wx, Sat wy, Sat wz;\t\t" << "Sat ax, Sat ay, Sat az;\t\t";
         std::cout << "Accel x, Accel y, Accel z;\t";// << "Gyro x, Gyro y, Gyro z;\t\t";
         for (uint32_t i = 0; i < num_reaction_wheels; i++)
@@ -100,7 +100,7 @@ void Messenger::write_csv_header(uint32_t num_reaction_wheels)
     this->output_file_buffer.str(std::string());
 
     /* Write the new header */
-    this->output_file_buffer << "Time,Satellite theta x,Satellite theta y,Satellite theta z,Satellite Omega x,Satellite Omega y,Satellite Omega z,";
+    this->output_file_buffer << "Time,Timestep,Satellite theta x,Satellite theta y,Satellite theta z,Satellite Omega x,Satellite Omega y,Satellite Omega z,";
     this->output_file_buffer << "Satellite alpha x,Satellite alpha y,Satellite alpha z,Accelerometer x,Accelerometer y,Accelerometer z,";//Gyro x,Gyro y,Gyro z,";
     for (uint32_t i = 0; i < num_reaction_wheels; i++)
     {
@@ -112,7 +112,7 @@ void Messenger::write_csv_header(uint32_t num_reaction_wheels)
 }
 
 
-void Messenger::update_simulation_state(sim_config state, timestamp time)
+void Messenger::update_simulation_state(sim_config state, timestamp time, timestamp timestep)
 {
     terminal_write_count++;
     csv_write_count++;
@@ -120,13 +120,13 @@ void Messenger::update_simulation_state(sim_config state, timestamp time)
     if ( (!silent_sim_prints) &&
          (terminal_print_rate <= terminal_write_count) )
     {
-        this->append_cout_output(state, time);
+        this->append_cout_output(state, time, timestep);
     }
 
     if ( (csv_print_rate <= csv_write_count) &&
          (!silent_csv_prints) )
     {
-        this->append_csv_output(state, time);
+        this->append_csv_output(state, time, timestep);
         csv_write_count = 0;
     }
 
@@ -134,10 +134,9 @@ void Messenger::update_simulation_state(sim_config state, timestamp time)
     return;
 }
 
-void Messenger::append_cout_output(sim_config state, timestamp time)
+void Messenger::append_cout_output(sim_config state, timestamp time, timestamp timestep)
 {
-    std::cout << std::setw(6) << std::setfill('0') << std::setprecision(5) << std::internal;
-    std::cout << text_colour.reset << time.pretty_string() << "\t" << std::setprecision(4) << std::fixed;
+    std::cout << text_colour.reset << time.pretty_string() << "\t" << timestep.pretty_string() << "\t";
     std::cout << state.satellite.theta_b.x() << ", " << state.satellite.theta_b.y() << ", " << state.satellite.theta_b.z() << ";\t\t";
     std::cout << state.satellite.omega_b.x() << ", " << state.satellite.omega_b.y() << ", " << state.satellite.omega_b.z() << ";\t\t";
     std::cout << state.satellite.alpha_b.x() << ", " << state.satellite.alpha_b.y() << ", " << state.satellite.alpha_b.z() << ";\t";
@@ -159,9 +158,9 @@ void Messenger::append_cout_output(sim_config state, timestamp time)
     terminal_write_count = 0;
 }
 
-void Messenger::append_csv_output(sim_config state, timestamp time)
+void Messenger::append_csv_output(sim_config state, timestamp time, timestamp timestep)
 {
-    this->output_file_buffer << (float)time << ",";
+    this->output_file_buffer << (float)time << "," << (float)timestep <<",";
     this->output_file_buffer << state.satellite.theta_b.x() << "," << state.satellite.theta_b.y() << "," << state.satellite.theta_b.z() << ",";
     this->output_file_buffer << state.satellite.omega_b.x() << "," << state.satellite.omega_b.y() << "," << state.satellite.omega_b.z() << ",";
     this->output_file_buffer << state.satellite.alpha_b.x() << "," << state.satellite.alpha_b.y() << "," << state.satellite.alpha_b.z() << ",";

--- a/csdc-6/adcs-simulation/cpp/src/Messenger.cpp
+++ b/csdc-6/adcs-simulation/cpp/src/Messenger.cpp
@@ -114,22 +114,19 @@ void Messenger::write_csv_header(uint32_t num_reaction_wheels)
 
 void Messenger::update_simulation_state(sim_config state, timestamp time, timestamp timestep)
 {
-    terminal_write_count++;
-    csv_write_count++;
-
     if ( (!silent_sim_prints) &&
-         (terminal_print_rate <= terminal_write_count) )
+         (terminal_print_rate <= (time - previous_terminal_write)) )
     {
         this->append_cout_output(state, time, timestep);
+        previous_terminal_write = time;
     }
 
-    if ( (csv_print_rate <= csv_write_count) &&
-         (!silent_csv_prints) )
+    if ( (!silent_csv_prints) &&
+         (csv_print_rate <= (time - previous_csv_write)) )
     {
         this->append_csv_output(state, time, timestep);
-        csv_write_count = 0;
+        previous_csv_write = time;
     }
-
 
     return;
 }
@@ -145,7 +142,7 @@ void Messenger::append_cout_output(sim_config state, timestamp time, timestamp t
     // std::cout << state.gyroscope.measurement.x()     << ", " << state.gyroscope.measurement.y()     << ", " << state.gyroscope.measurement.z() << ";";
 
     for (uint32_t i = 0; i < state.reaction_wheels.size(); i++)
-    {   
+    {
         std::cout << "\t" << state.reaction_wheels.at(i).omega << ", " << state.reaction_wheels.at(i).alpha << ";";
 
         if (i < state.reaction_wheels.size() - 1)
@@ -155,7 +152,7 @@ void Messenger::append_cout_output(sim_config state, timestamp time, timestamp t
     }
     std::cout << std::endl;
 
-    terminal_write_count = 0;
+    return;
 }
 
 void Messenger::append_csv_output(sim_config state, timestamp time, timestamp timestep)
@@ -261,15 +258,15 @@ void Messenger::reset_defaults()
 
 void Messenger::set_csv_print_rate(uint32_t csv_rate)
 {
-    this->csv_print_rate = csv_rate;
-    this->send_message("CSV update period: " + std::to_string(this->csv_print_rate) + "ms.");
+    this->csv_print_rate = timestamp(csv_rate,0);
+    this->send_message("CSV update period: " + this->csv_print_rate.pretty_string() + "ms.");
     return;
 }
 
 void Messenger::set_terminal_print_rate(uint32_t terminal_rate)
 {
-    this->terminal_print_rate = terminal_rate;
-    this->send_message("Terminal print period: " + std::to_string(this->terminal_print_rate) + "ms.");
+    this->terminal_print_rate = timestamp(terminal_rate,0);
+    this->send_message("Terminal print period: " + this->terminal_print_rate.pretty_string() + "ms.");
     return;
 }
 

--- a/csdc-6/adcs-simulation/cpp/src/Simulator.cpp
+++ b/csdc-6/adcs-simulation/cpp/src/Simulator.cpp
@@ -51,7 +51,7 @@ timestamp Simulator::update_simulation() {
     return this->simulation_time;
 }
 
-timestamp Simulator::determine_timestep() 
+void Simulator::determine_timestep() 
 {
     //2*max error is defined as 2*0.005 degrees = 0.01 degrees
     if (true == this->variableTimestep)
@@ -71,7 +71,7 @@ timestamp Simulator::determine_timestep()
         }
     }
 
-    return timestep_length;
+    return;
 }
 
 timestamp Simulator::set_adcs_sleep(timestamp duration) {

--- a/csdc-6/adcs-simulation/cpp/src/UI.cpp
+++ b/csdc-6/adcs-simulation/cpp/src/UI.cpp
@@ -694,6 +694,7 @@ void UI::run_controller_unit_tests(std::vector<std::string> args)
         "100",
         "-p",
         "100000",
+        "-sp"
     };
 
     for (uint8_t test_num = 1; test_num <= num_controller_unit_tests; test_num++)

--- a/csdc-6/adcs-simulation/cpp/src/UI.cpp
+++ b/csdc-6/adcs-simulation/cpp/src/UI.cpp
@@ -145,7 +145,23 @@ void UI::run_simulation(std::vector<std::string> args)
 
         /* Get Simulation config info */
         timestamp timeout(config.getTimeout(),0);
-        simulator.init(this->get_sim_config(config), timeout);
+        timestamp initial_timestep = timestamp(config.GetTimestepInMilliSeconds(),0);
+        if (0 == initial_timestep)
+        {
+            initial_timestep = timestamp(1,0);
+        }
+
+        bool variableTimestep = config.GetTimestepDecision();
+        timestamp max_timestep = timestamp(0,0);
+        timestamp min_timestamp = timestamp(0,0);
+
+        if (true == variableTimestep)
+        {
+            max_timestep = config.GetMaxTimestep();
+            min_timestamp = config.GetMinTimestep();
+        }
+
+        simulator.init(this->get_sim_config(config), timeout, initial_timestep, variableTimestep, max_timestep, min_timestamp);
 
         /* Timer used for control code */
         ADCS_timer timer(&simulator);
@@ -678,7 +694,6 @@ void UI::run_controller_unit_tests(std::vector<std::string> args)
         "100",
         "-p",
         "100000",
-        "-sp"
     };
 
     for (uint8_t test_num = 1; test_num <= num_controller_unit_tests; test_num++)

--- a/csdc-6/adcs-simulation/cpp/unit_tests/controller/test_config_1.yaml
+++ b/csdc-6/adcs-simulation/cpp/unit_tests/controller/test_config_1.yaml
@@ -98,7 +98,7 @@ Sensors:
 VariableTimestep: TRUE
 
 # TimeStepMax: [int], in ms, only use if VariableTimestep: TRUE
-TimeStepMax: 50
+TimeStepMax: 20
 # TimeStepMin: [int], in ms, only use if VariableTimestep: TRUE
 TimeStepMin: 1
 

--- a/csdc-6/adcs-simulation/cpp/unit_tests/controller/test_config_1.yaml
+++ b/csdc-6/adcs-simulation/cpp/unit_tests/controller/test_config_1.yaml
@@ -94,8 +94,16 @@ Sensors:
     PollingTime: 10
     Position: [0,0,0]
 
-# Timestep: [int], in ms
-TimeStep: 1
+# VariableTimestep: [bool], TRUE for variable timestep, FALSE for fixed timestep
+VariableTimestep: TRUE
+
+# TimeStepMax: [int], in ms, only use if VariableTimestep: TRUE
+TimeStepMax: 50
+# TimeStepMin: [int], in ms, only use if VariableTimestep: TRUE
+TimeStepMin: 1
+
+# Timestep: [int], in ms, only use if VaraibleTimestep: FALSE
+#TimeStep: 2
 
 # Timeout: [int], in ms
-Timeout: 600000
+Timeout: 1000

--- a/csdc-6/adcs-simulation/cpp/unit_tests/controller/test_config_2.yaml
+++ b/csdc-6/adcs-simulation/cpp/unit_tests/controller/test_config_2.yaml
@@ -98,12 +98,12 @@ Sensors:
 VariableTimestep: TRUE
 
 # TimeStepMax: [int], in ms, only use if VariableTimestep: TRUE
-TimeStepMax: 50
+TimeStepMax: 10
 # TimeStepMin: [int], in ms, only use if VariableTimestep: TRUE
 TimeStepMin: 1
 
 # Timestep: [int], in ms, only use if VaraibleTimestep: FALSE
-#TimeStep: 2
+# TimeStep: 1
 
 # Timeout: [int], in ms
 Timeout: 600000

--- a/csdc-6/adcs-simulation/cpp/unit_tests/controller/test_config_2.yaml
+++ b/csdc-6/adcs-simulation/cpp/unit_tests/controller/test_config_2.yaml
@@ -94,8 +94,16 @@ Sensors:
     PollingTime: 10
     Position: [0,0,0]
 
-# Timestep: [int], in ms
-TimeStep: 2
+# VariableTimestep: [bool], TRUE for variable timestep, FALSE for fixed timestep
+VariableTimestep: TRUE
+
+# TimeStepMax: [int], in ms, only use if VariableTimestep: TRUE
+TimeStepMax: 50
+# TimeStepMin: [int], in ms, only use if VariableTimestep: TRUE
+TimeStepMin: 1
+
+# Timestep: [int], in ms, only use if VaraibleTimestep: FALSE
+#TimeStep: 2
 
 # Timeout: [int], in ms
 Timeout: 600000

--- a/csdc-6/adcs-simulation/cpp/unit_tests/controller/test_config_3.yaml
+++ b/csdc-6/adcs-simulation/cpp/unit_tests/controller/test_config_3.yaml
@@ -94,8 +94,16 @@ Sensors:
     PollingTime: 10
     Position: [0,0,0]
 
-# Timestep: [int], in ms
-TimeStep: 1
+# VariableTimestep: [bool], TRUE for variable timestep, FALSE for fixed timestep
+VariableTimestep: TRUE
+
+# TimeStepMax: [int], in ms, only use if VariableTimestep: TRUE
+TimeStepMax: 50
+# TimeStepMin: [int], in ms, only use if VariableTimestep: TRUE
+TimeStepMin: 1
+
+# Timestep: [int], in ms, only use if VaraibleTimestep: FALSE
+#TimeStep: 2
 
 # Timeout: [int], in ms
 Timeout: 600000

--- a/csdc-6/adcs-simulation/cpp/unit_tests/controller/test_config_3.yaml
+++ b/csdc-6/adcs-simulation/cpp/unit_tests/controller/test_config_3.yaml
@@ -98,12 +98,12 @@ Sensors:
 VariableTimestep: TRUE
 
 # TimeStepMax: [int], in ms, only use if VariableTimestep: TRUE
-TimeStepMax: 50
+TimeStepMax: 10
 # TimeStepMin: [int], in ms, only use if VariableTimestep: TRUE
 TimeStepMin: 1
 
 # Timestep: [int], in ms, only use if VaraibleTimestep: FALSE
-#TimeStep: 2
+# TimeStep: 1
 
 # Timeout: [int], in ms
 Timeout: 600000

--- a/csdc-6/adcs-simulation/cpp/unit_tests/no_controller/unit_test_1.yaml
+++ b/csdc-6/adcs-simulation/cpp/unit_tests/no_controller/unit_test_1.yaml
@@ -60,6 +60,14 @@ Sensors:
     PollingTime: 10
     Position: [0,0,0]
 
+# VariableTimestep: [bool], TRUE for variable timestep, FALSE for fixed timestep
+VariableTimestep: FALSE
+
+# TimeStepMax: [int], in ms, only use if VariableTimestep: TRUE
+# TimeStepMax: 50
+# TimeStepMin: [int], in ms, only use if VariableTimestep: TRUE
+# TimeStepMin: 1
+
 # Timestep: [int], in ms
 TimeStep: 1
 

--- a/csdc-6/adcs-simulation/cpp/unit_tests/no_controller/unit_test_2.yaml
+++ b/csdc-6/adcs-simulation/cpp/unit_tests/no_controller/unit_test_2.yaml
@@ -60,6 +60,14 @@ Sensors:
     PollingTime: 10
     Position: [0,0,0]
 
+# VariableTimestep: [bool], TRUE for variable timestep, FALSE for fixed timestep
+VariableTimestep: FALSE
+
+# TimeStepMax: [int], in ms, only use if VariableTimestep: TRUE
+# TimeStepMax: 50
+# TimeStepMin: [int], in ms, only use if VariableTimestep: TRUE
+# TimeStepMin: 1
+
 # Timestep: [int], in ms
 TimeStep: 1
 

--- a/csdc-6/adcs-simulation/cpp/unit_tests/no_controller/unit_test_3.yaml
+++ b/csdc-6/adcs-simulation/cpp/unit_tests/no_controller/unit_test_3.yaml
@@ -60,6 +60,14 @@ Sensors:
     PollingTime: 10
     Position: [0,0,0]
 
+# VariableTimestep: [bool], TRUE for variable timestep, FALSE for fixed timestep
+VariableTimestep: FALSE
+
+# TimeStepMax: [int], in ms, only use if VariableTimestep: TRUE
+# TimeStepMax: 50
+# TimeStepMin: [int], in ms, only use if VariableTimestep: TRUE
+# TimeStepMin: 1
+
 # Timestep: [int], in ms
 TimeStep: 1
 

--- a/csdc-6/adcs-simulation/cpp/unit_tests/no_controller/unit_test_4.yaml
+++ b/csdc-6/adcs-simulation/cpp/unit_tests/no_controller/unit_test_4.yaml
@@ -60,6 +60,14 @@ Sensors:
     PollingTime: 10
     Position: [0,0,0]
 
+# VariableTimestep: [bool], TRUE for variable timestep, FALSE for fixed timestep
+VariableTimestep: FALSE
+
+# TimeStepMax: [int], in ms, only use if VariableTimestep: TRUE
+# TimeStepMax: 50
+# TimeStepMin: [int], in ms, only use if VariableTimestep: TRUE
+# TimeStepMin: 1
+
 # Timestep: [int], in ms
 TimeStep: 1
 

--- a/csdc-6/adcs-simulation/cpp/unit_tests/no_controller/unit_test_5.yaml
+++ b/csdc-6/adcs-simulation/cpp/unit_tests/no_controller/unit_test_5.yaml
@@ -60,6 +60,14 @@ Sensors:
     PollingTime: 10
     Position: [0,0,0]
 
+# VariableTimestep: [bool], TRUE for variable timestep, FALSE for fixed timestep
+VariableTimestep: FALSE
+
+# TimeStepMax: [int], in ms, only use if VariableTimestep: TRUE
+# TimeStepMax: 50
+# TimeStepMin: [int], in ms, only use if VariableTimestep: TRUE
+# TimeStepMin: 1
+
 # Timestep: [int], in ms
 TimeStep: 1
 

--- a/csdc-6/adcs-simulation/cpp/unit_tests/no_controller/unit_test_6.yaml
+++ b/csdc-6/adcs-simulation/cpp/unit_tests/no_controller/unit_test_6.yaml
@@ -60,6 +60,14 @@ Sensors:
     PollingTime: 10
     Position: [0,0,0]
 
+# VariableTimestep: [bool], TRUE for variable timestep, FALSE for fixed timestep
+VariableTimestep: FALSE
+
+# TimeStepMax: [int], in ms, only use if VariableTimestep: TRUE
+# TimeStepMax: 50
+# TimeStepMin: [int], in ms, only use if VariableTimestep: TRUE
+# TimeStepMin: 1
+
 # Timestep: [int], in ms
 TimeStep: 1
 

--- a/csdc-6/adcs-simulation/cpp/unit_tests/performance/perf_test_config_1.yaml
+++ b/csdc-6/adcs-simulation/cpp/unit_tests/performance/perf_test_config_1.yaml
@@ -94,8 +94,16 @@ Sensors:
     PollingTime: 10
     Position: [0,0,0]
 
-# Timestep: [int], in ms
-TimeStep: 100
+# VariableTimestep: [bool], TRUE for variable timestep, FALSE for fixed timestep
+VariableTimestep: TRUE
+
+# TimeStepMax: [int], in ms, only use if VariableTimestep: TRUE
+TimeStepMax: 50
+# TimeStepMin: [int], in ms, only use if VariableTimestep: TRUE
+TimeStepMin: 1
+
+# Timestep: [int], in ms, only use if VaraibleTimestep: FALSE
+#TimeStep: 100
 
 # Timeout: [int], in ms
 Timeout: 1000

--- a/csdc-6/adcs-simulation/cpp/unit_tests/performance/perf_test_config_2.yaml
+++ b/csdc-6/adcs-simulation/cpp/unit_tests/performance/perf_test_config_2.yaml
@@ -94,8 +94,16 @@ Sensors:
     PollingTime: 10
     Position: [0,0,0]
 
+# VariableTimestep: [bool], TRUE for variable timestep, FALSE for fixed timestep
+VariableTimestep: TRUE
+
+# TimeStepMax: [int], in ms, only use if VariableTimestep: TRUE
+TimeStepMax: 50
+# TimeStepMin: [int], in ms, only use if VariableTimestep: TRUE
+TimeStepMin: 1
+
 # Timestep: [int], in ms
-TimeStep: 100
+# TimeStep: 100
 
 # Timeout: [int], in ms
 Timeout: 300000

--- a/csdc-6/adcs-simulation/cpp/unit_tests/performance/perf_test_config_3.yaml
+++ b/csdc-6/adcs-simulation/cpp/unit_tests/performance/perf_test_config_3.yaml
@@ -94,8 +94,16 @@ Sensors:
     PollingTime: 10
     Position: [0,0,0]
 
+# VariableTimestep: [bool], TRUE for variable timestep, FALSE for fixed timestep
+VariableTimestep: TRUE
+
+# TimeStepMax: [int], in ms, only use if VariableTimestep: TRUE
+TimeStepMax: 50
+# TimeStepMin: [int], in ms, only use if VariableTimestep: TRUE
+TimeStepMin: 1
+
 # Timestep: [int], in ms
-TimeStep: 1
+#TimeStep: 1
 
 # Timeout: [int], in ms
 Timeout: 300000


### PR DESCRIPTION
CHANGES
- Added variable timestep algorithm in Simulator.cpp
- Added variable timestep parameters to the YAMLs

REASON
Improves performance testing while retaining accuracy of low timesteps.

TESTING
Tests conducted using the second controller yaml file.

GITHUB LINK
https://github.com/queens-satellite-team/adcs/issues/66

Signed-off-by: Aidan Sheedy <Aidan.P.Sheedy@gmail.com>